### PR TITLE
feat: add support for ManiaPlanet4 (MP4) aka TrackMania 2.

### DIFF
--- a/Source/Dashboard.as
+++ b/Source/Dashboard.as
@@ -40,10 +40,10 @@ class Dashboard
 	CGamePlayer@ GetViewingPlayer()
 	{
 		auto playground = GetApp().CurrentPlayground;
-		if (playground is null || playground.GameTerminals.Length != 1) {
+		if (playground is null || playground.Interface is null) {
 			return null;
 		}
-		return playground.GameTerminals[0].GUIPlayer;
+        return cast<CTrackManiaRaceInterface>(playground.Interface).UiPlayer0;
 	}
 #endif
 

--- a/Source/Dashboard.as
+++ b/Source/Dashboard.as
@@ -40,10 +40,10 @@ class Dashboard
 	CGamePlayer@ GetViewingPlayer()
 	{
 		auto playground = GetApp().CurrentPlayground;
-		if (playground is null || playground.Interface is null) {
+		if (playground is null || playground.GameTerminals.Length != 1) {
 			return null;
 		}
-        return cast<CTrackManiaRaceInterface>(playground.Interface).UiPlayer0;
+		return playground.GameTerminals[0].GUIPlayer;
 	}
 #endif
 

--- a/Source/Dashboard.as
+++ b/Source/Dashboard.as
@@ -36,6 +36,15 @@ class Dashboard
 		}
 		return playground.LocalPlayerMobil;
 	}
+#elif MP4
+	CGamePlayer@ GetViewingPlayer()
+	{
+		auto playground = GetApp().CurrentPlayground;
+		if (playground is null || playground.GameTerminals.Length != 1) {
+			return null;
+		}
+		return playground.GameTerminals[0].GUIPlayer;
+	}
 #endif
 
 #if !COMPETITION
@@ -81,11 +90,6 @@ class Dashboard
 	{
 		auto app = GetApp();
 
-		auto sceneVis = app.GameScene;
-		if (sceneVis is null) {
-			return;
-		}
-
 		// Interface hidden
 		if (Setting_General_HideOnHiddenInterface) {
 			if (app.CurrentPlayground !is null && app.CurrentPlayground.Interface !is null) {
@@ -94,8 +98,16 @@ class Dashboard
 				}
 			}
 		}
-
+#if !MP4
+		auto sceneVis = app.GameScene;
+		if (sceneVis is null) {
+			return;
+		}
 		CSceneVehicleVis@ vis = null;
+#else
+		CGameScene@ sceneVis = null;
+		CSceneVehicleVisInner@ vis = null;
+#endif
 
 		auto player = GetViewingPlayer();
 		if (player !is null) {

--- a/Source/Helpers/Vehicle/VehicleMP4.as
+++ b/Source/Helpers/Vehicle/VehicleMP4.as
@@ -1,0 +1,105 @@
+// This file contains code to access some visual information that is not normally available. This
+// code isn't entirely future-proof, so it might stop working after some game updates. If you want
+// to use this code keep this in mind! Use `#max_game_version` to avoid crashes on unexpected game
+// updates.
+
+#if MP4
+class CSceneVehicleVisInner
+{
+	CTrackManiaPlayer@ m_player;
+
+	CSceneVehicleVisState@ AsyncState;
+
+	CSceneVehicleVisInner(CGamePlayer@ player)
+	{
+		@m_player = cast<CTrackManiaPlayer>(player);
+
+		@AsyncState = CSceneVehicleVisState(m_player);
+	}
+}
+
+class CSceneVehicleVisState
+{
+	CTrackManiaPlayer@ m_player;
+	CTrackManiaScriptPlayer@ m_scriptapi;
+
+	CSceneVehicleVisState(CTrackManiaPlayer@ player)
+	{
+		@m_player = player;
+		@m_scriptapi = m_player.ScriptAPI;
+	}
+
+	float get_InputSteer() { if (m_scriptapi is null) { return 0; } return m_scriptapi.InputSteer; }
+	float get_InputGasPedal() { if (m_scriptapi is null) { return 0; } return m_scriptapi.InputGasPedal; }
+	float get_InputBrakePedal() { if (m_scriptapi is null) { return 0; } return m_scriptapi.InputIsBraking ? 1 : 0; }
+	bool get_InputIsBraking() { if (m_scriptapi is null) { return false; } return m_scriptapi.InputIsBraking; }
+
+	uint get_CurGear() { if (m_scriptapi is null) { return 0; } return m_scriptapi.EngineCurGear; }
+
+	float get_RPM() { if (m_scriptapi is null) { return 0; } return m_scriptapi.EngineRpm; }
+
+	float get_FrontSpeed() { if (m_scriptapi is null) { return 0; } return m_scriptapi.Speed; }
+	float get_SideSpeed() { return 0; }
+
+	vec3 get_Position() { if (m_scriptapi is null) { return vec3(); } return m_scriptapi.Position; }
+	vec3 get_WorldVel() { return vec3(); }
+
+	float get_FLWheelRot() { return 0; }
+	float get_FLWheelRotSpeed() { return 0; }
+	float get_FLSteerAngle() { return 0; }
+	float get_FLSlipCoef() { return 0; }
+
+	float get_FRWheelRot() { return 0; }
+	float get_FRWheelRotSpeed() { return 0; }
+	float get_FRSteerAngle() { return 0; }
+	float get_FRSlipCoef() { return 0; }
+
+	float get_RLWheelRot() { return 0; }
+	float get_RLWheelRotSpeed() { return 0; }
+	float get_RLSteerAngle() { return 0; }
+	float get_RLSlipCoef() { return 0; }
+
+	float get_RRWheelRot() { return 0; }
+	float get_RRWheelRotSpeed() { return 0; }
+	float get_RRSteerAngle() { return 0; }
+	float get_RRSlipCoef() { return 0; }
+}
+
+namespace Vehicle
+{
+	// Get vehicle vis from a given player.
+	CSceneVehicleVisInner@ GetVis(CGameScene@ sceneVis, CGamePlayer@ player)
+	{
+		if (player is null) {
+			return null;
+		}
+		return CSceneVehicleVisInner(player);
+	}
+
+	// Not used for anything in MP4 afaik, but keeping the interface identical.
+	CSceneVehicleVisInner@ GetSingularVis(CGameScene@ sceneVis)
+	{
+		return null;
+	}
+
+	// Get RPM for vehicle vis. This is contained within the state, but not exposed by default, which
+	// is why this function exists.
+	float GetRPM(CSceneVehicleVisState@ vis)
+	{
+		return vis.RPM;
+	}
+
+	// Get relative side speed for vehicle.
+	float GetSideSpeed(CSceneVehicleVisState@ vis)
+	{
+		return vis.SideSpeed;
+	}
+
+	// Get entity ID of the given vehicle vis.
+	uint GetEntityId(CSceneVehicleVisInner@ vis)
+	{
+		// Not present
+		return 0;
+	}
+}
+#endif


### PR DESCRIPTION
Implemented by adding `VehicleMP4.as` that contains an interface to get the data we want.

Also required adjustments to `Dashboard.as` because `CSceneVehicleVis` can't be used in MP4, as such it was replaced with `CSceneVehicleVisInner`.
We needed to do this because because `CSceneVehicleVis` is a class in the game and doesn't have the data we need.

Additionally, we use the currently viewed player's script API to get the data we want.

Note that a lot of information present in TM2020 or TM Ultra is unavailable in MP4 (or at least I don't know where it is):
- Wheel rotation, rotation speed, steer angle, slip coefficient
- World velocity
- Side speed

Note that spectated players don't work fully either, specifically the only information available for a spectated player is their Speed and Engine RPM.