### PR TITLE
feat: add km/h/s as a possible unit of measurement for the accelerometer

### DIFF
--- a/Source/Settings.as
+++ b/Source/Settings.as
@@ -210,6 +210,15 @@ vec4 Setting_Gearbox_TextColor = vec4(1, 1, 1, 1);
 string Setting_Gearbox_Font = "DroidSans.ttf";
 
 
+enum AccelerationUnit
+{
+	MetersPerSecondPerSecond,
+	KilometersPerHourPerSecond
+}
+
+[Setting category="Acceleration" name="Acceleration unit of measurement" description="Make sure to change max acceleration, for km/h/s = 54, for m/s/s = 15"]
+AccelerationUnit Setting_Acceleration_Unit = AccelerationUnit::MetersPerSecondPerSecond;
+
 [Setting category="Acceleration" name="Positive acceleration color" color]
 vec4 Setting_Acceleration_Positive_Color = vec4(0, 0.9f, 0, 1);
 
@@ -229,7 +238,7 @@ float Setting_Acceleration_BorderWidth = 3.0f;
 float Setting_Acceleration_BorderRadius = 5.0f;
 
 [Setting category="Acceleration" name="Maximum acceleration value" drag min=0 max=250]
-float Setting_Acceleration_MaximumAcceleration = 54.0f;
+float Setting_Acceleration_MaximumAcceleration = 15.0f;
 
 [Setting category="Acceleration" name="Show text value"]
 bool Setting_Acceleration_ShowTextValue = true;

--- a/Source/Settings.as
+++ b/Source/Settings.as
@@ -228,8 +228,8 @@ float Setting_Acceleration_BorderWidth = 3.0f;
 [Setting category="Acceleration" name="Border radius" drag min=0 max=50]
 float Setting_Acceleration_BorderRadius = 5.0f;
 
-[Setting category="Acceleration" name="Maximum acceleration value" drag min=0 max=200]
-float Setting_Acceleration_MaximumAcceleration = 15.0f;
+[Setting category="Acceleration" name="Maximum acceleration value" drag min=0 max=250]
+float Setting_Acceleration_MaximumAcceleration = 54.0f;
 
 [Setting category="Acceleration" name="Show text value"]
 bool Setting_Acceleration_ShowTextValue = true;

--- a/Source/Settings.as
+++ b/Source/Settings.as
@@ -216,7 +216,7 @@ enum AccelerationUnit
 	KilometersPerHourPerSecond
 }
 
-[Setting category="Acceleration" name="Acceleration unit of measurement" description="Make sure to change max acceleration, for km/h/s = 54, for m/s/s = 15"]
+[Setting category="Acceleration" name="Acceleration unit of measurement"]
 AccelerationUnit Setting_Acceleration_Unit = AccelerationUnit::MetersPerSecondPerSecond;
 
 [Setting category="Acceleration" name="Positive acceleration color" color]
@@ -237,8 +237,11 @@ float Setting_Acceleration_BorderWidth = 3.0f;
 [Setting category="Acceleration" name="Border radius" drag min=0 max=50]
 float Setting_Acceleration_BorderRadius = 5.0f;
 
-[Setting category="Acceleration" name="Maximum acceleration value" drag min=0 max=250]
-float Setting_Acceleration_MaximumAcceleration = 15.0f;
+[Setting category="Acceleration" name="Maximum acceleration value for m/s/s" drag min=0 max=250]
+float Setting_Acceleration_MaximumAccelerationMSS = 15.0f;
+
+[Setting category="Acceleration" name="Maximum acceleration value for km/h/s" drag min=0 max=250]
+float Setting_Acceleration_MaximumAccelerationKMHS = 54.0f;
 
 [Setting category="Acceleration" name="Show text value"]
 bool Setting_Acceleration_ShowTextValue = true;

--- a/Source/Things/Acceleration.as
+++ b/Source/Things/Acceleration.as
@@ -114,7 +114,10 @@ class DashboardAcceleration : DashboardThing
 	void Render(CSceneVehicleVisState@ vis) override
 	{
 		float speed = vis.FrontSpeed;
-		float curr_acc = ((speed - prev_speed) / (g_dt/1000)) * 3.6;
+		float curr_acc = ((speed - prev_speed) / (g_dt/1000));
+		if (Setting_Acceleration_Unit == AccelerationUnit::KilometersPerHourPerSecond) {
+			curr_acc *= 3.6;
+		}
 		prev_speed = speed;
 
 		vec2 offset = vec2(0.0f, 0.0f);

--- a/Source/Things/Acceleration.as
+++ b/Source/Things/Acceleration.as
@@ -34,9 +34,10 @@ class DashboardAcceleration : DashboardThing
 
 	void RenderNegativeAccelerometer(const vec2 &in pos, const vec2 &in size, float acc)
 	{
+		float max_accel = (Setting_Acceleration_Unit == AccelerationUnit::KilometersPerHourPerSecond) ? Setting_Acceleration_MaximumAccelerationKMHS : Setting_Acceleration_MaximumAccelerationMSS;
 		vec2 psize = vec2(size.x, size.y/2);
 		vec2 npos = vec2(pos.x, pos.y);
-		float accHeight = (acc / Setting_Acceleration_MaximumAcceleration) * psize.y;
+		float accHeight = (acc / max_accel) * psize.y;
 
 		nvg::Save();
 		nvg::BeginPath();
@@ -73,8 +74,9 @@ class DashboardAcceleration : DashboardThing
 
 	void RenderPositiveAccelerometer(const vec2 &in pos, const vec2 &in size, float acc)
 	{
+		float max_accel = (Setting_Acceleration_Unit == AccelerationUnit::KilometersPerHourPerSecond) ? Setting_Acceleration_MaximumAccelerationKMHS : Setting_Acceleration_MaximumAccelerationMSS;
 		vec2 psize = vec2(size.x, size.y/2);
-		float accHeight = (acc / Setting_Acceleration_MaximumAcceleration) * psize.y;
+		float accHeight = (acc / max_accel) * psize.y;
 
 		nvg::Save();
 		nvg::BeginPath();

--- a/Source/Things/Acceleration.as
+++ b/Source/Things/Acceleration.as
@@ -114,7 +114,7 @@ class DashboardAcceleration : DashboardThing
 	void Render(CSceneVehicleVisState@ vis) override
 	{
 		float speed = vis.FrontSpeed;
-		float curr_acc = ((speed - prev_speed) / (g_dt/1000));
+		float curr_acc = ((speed - prev_speed) / (g_dt/1000)) * 3.6;
 		prev_speed = speed;
 
 		vec2 offset = vec2(0.0f, 0.0f);


### PR DESCRIPTION
feat: add km/h/s as a possible unit of measurement for the accelerometer.

This change makes it possible to switch between meters/s/s and km/h/s as the unit of measurement for the accelerometer Thing.
The actual implementation change is adding an enum type that is used for a setting `Setting_Acceleration_Unit`, and the accelerometer checks whether this is set to km/h/s and if it is it multiplies the calculated acceleration in m/s/s by 3.6 to get the correct value in km/h/s.

Additionally modifies the settings that controls the max acceleration for the accelerometer, one for m/s/s and one for km/h/s. This is done instead of multiplying the previous setting by 3.6 if the unit is set to km/h/s as that seemed like it would be confusing.