### PR TITLE
Animate keyboard keys upon release

### DIFF
--- a/Source/Dashboard.as
+++ b/Source/Dashboard.as
@@ -167,4 +167,10 @@ class Dashboard
 			m_speed.InternalRender(vis.AsyncState);
 		}
 	}
+
+	void Update(float dt) {
+		if (m_pad !is null) {
+			m_pad.Update(dt);
+		}
+	}
 }

--- a/Source/Main.as
+++ b/Source/Main.as
@@ -66,6 +66,10 @@ void Update(float dt)
 	// Specifically to get an accurate acceleration value in meters per second per second.
 	// Without this dt we can only get a fake 'acceleration' that doesn't incorporate time properly.
 	g_dt = dt;
+
+	if (g_dashboard !is null) {
+		g_dashboard.Update(dt);
+	}
 }
 
 void OnSettingsChanged()

--- a/Source/Pads/Keyboard.as
+++ b/Source/Pads/Keyboard.as
@@ -1,6 +1,13 @@
 #if !COMPETITION
 class DashboardPadKeyboard : DashboardThing
 {
+	float m_keyLeftAnimFactor;
+	float m_keyRightAnimFactor;
+	float m_keyUpAnimFactor;
+	float m_keyDownAnimFactor;
+	float m_lastSteerValueLeft;
+	float m_lastSteerValueRight;
+
 	DashboardPadKeyboard()
 	{
 		super();
@@ -15,52 +22,88 @@ class DashboardPadKeyboard : DashboardThing
 
 		float steerLeft = vis.InputSteer < 0 ? Math::Abs(vis.InputSteer) : 0.0f;
 		float steerRight = vis.InputSteer > 0 ? vis.InputSteer : 0.0f;
+		float inputUp = vis.InputGasPedal;
+		float inputDown = vis.InputIsBraking ? 1.0f : vis.InputBrakePedal;
 
-		RenderKey(vec2(keySize.x + Setting_Keyboard_Spacing, 0), keySize, Icons::AngleUp, vis.InputGasPedal);
-		RenderKey(vec2(keySize.x + Setting_Keyboard_Spacing, keySize.y + Setting_Keyboard_Spacing), keySize, Icons::AngleDown, vis.InputIsBraking ? 1.0f : vis.InputBrakePedal);
+		if (Math::Abs(steerLeft) > 0.0f) {
+			m_keyLeftAnimFactor = 1.0f;
+			m_lastSteerValueLeft = steerLeft;
+		}
+		if (Math::Abs(steerRight) > 0.0f) {
+			m_keyRightAnimFactor = 1.0f;
+			m_lastSteerValueRight = steerRight;
+		}
+		if (Math::Abs(inputUp) > 0.1f) {
+			m_keyUpAnimFactor = 1.0f;
+		}
+		if (Math::Abs(inputDown) > 0.1f) {
+			m_keyDownAnimFactor = 1.0f;
+		}
 
-		RenderKey(vec2(0, keySize.y + Setting_Keyboard_Spacing), keySize, Icons::AngleLeft, steerLeft, -1);
-		RenderKey(vec2(keySize.x * 2 + Setting_Keyboard_Spacing * 2, keySize.y + Setting_Keyboard_Spacing), keySize, Icons::AngleRight, steerRight, 1);
+		RenderKey(vec2(keySize.x + Setting_Keyboard_Spacing, 0), keySize, Icons::AngleUp, inputUp, m_keyUpAnimFactor);
+		RenderKey(vec2(keySize.x + Setting_Keyboard_Spacing, keySize.y + Setting_Keyboard_Spacing), keySize, Icons::AngleDown, inputDown, m_keyDownAnimFactor);
+
+		RenderKey(vec2(0, keySize.y + Setting_Keyboard_Spacing), keySize, Icons::AngleLeft, steerLeft, m_keyLeftAnimFactor, -1, m_lastSteerValueLeft);
+		RenderKey(vec2(keySize.x * 2 + Setting_Keyboard_Spacing * 2, keySize.y + Setting_Keyboard_Spacing), keySize, Icons::AngleRight, steerRight, m_keyRightAnimFactor, 1, m_lastSteerValueRight);
 	}
 
-	void RenderKey(const vec2 &in pos, const vec2 &in size, const string &in text, float value, int fillDir = 0)
+	void RenderKey(const vec2 &in pos, const vec2 &in size, const string &in text, float currValue, float animFactor, int fillDir = 0, float lastActiveValue = 0.0f)
 	{
+		float animFactorShrink = 1.0f;
+		float animFactorFade = 1.0f;
+		switch (Setting_Keyboard_ReleaseAnimation) {
+			case KeyboardAnimation::Shrink:
+				animFactorShrink = animFactor;
+				break;
+			case KeyboardAnimation::Fade:
+				animFactorFade = animFactor;
+				break;
+			case KeyboardAnimation::ShrinkAndFade:
+				animFactorShrink = animFactor;
+				animFactorFade = animFactor;
+				break;
+		}
+
 		vec4 borderColor = Setting_Keyboard_BorderColor;
 		if (fillDir == 0) {
-			borderColor.w *= Math::Abs(value) > 0.1f ? 1.0f : Setting_Keyboard_InactiveAlpha;
+			borderColor.w *= Math::Abs(currValue) > 0.1f ? 1.0f : Setting_Keyboard_InactiveAlpha;
 		} else {
-			borderColor.w *= Math::Lerp(Setting_Keyboard_InactiveAlpha, 1.0f, value);
+			borderColor.w *= Math::Lerp(Setting_Keyboard_InactiveAlpha, 1.0f, currValue);
 		}
 
 		nvg::BeginPath();
-		nvg::StrokeWidth(Setting_Keyboard_BorderWidth);
-
-		switch (Setting_Keyboard_Shape) {
-			case KeyboardShape::Rectangle: nvg::RoundedRect(pos.x, pos.y, size.x, size.y, Setting_Keyboard_BorderRadius); break;
-			case KeyboardShape::Ellipse: nvg::Ellipse(pos + size / 2, size.x / 2, size.y / 2); break;
-		}
-
+		SetNextShape(pos, size);
 		nvg::FillColor(Setting_Keyboard_EmptyFillColor);
 		nvg::Fill();
 
-		if (fillDir == 0) {
-			if (Math::Abs(value) > 0.1f) {
-				nvg::FillColor(Setting_Keyboard_FillColor);
+		nvg::BeginPath();
+		SetNextShape(pos, size, animFactorShrink);
+
+		vec4 fillColor = Setting_Keyboard_FillColor;
+		fillColor.w *= animFactorFade;
+
+		if ((Setting_Keyboard_ReleaseAnimation == KeyboardAnimation::None && currValue > 0.0f)
+			|| (Setting_Keyboard_ReleaseAnimation != KeyboardAnimation::None && animFactor > 0.0f)) {
+			if (fillDir == 0) {
+				nvg::FillColor(fillColor);
 				nvg::Fill();
+			} else {
+				float valueWidth = size.x * animFactorShrink * lastActiveValue;
+				float posOffset = fillDir == 1 ? 0.0f : (size.x * animFactorShrink) - valueWidth;
+				nvg::Scissor(
+					pos.x + (0.5f * size.x * (1.0f - animFactorShrink)) + posOffset,
+					pos.y + (0.5f * size.y * (1.0f - animFactorShrink)),
+					valueWidth,
+					size.y * animFactorShrink);
+				nvg::FillColor(fillColor);
+				nvg::Fill();
+				nvg::ResetScissor();
 			}
-		} else if (value > 0) {
-			if (fillDir == -1) {
-				float valueWidth = value * size.x;
-				nvg::Scissor(size.x - valueWidth, pos.y, valueWidth, size.y);
-			} else if (fillDir == 1) {
-				float valueWidth = value * size.x;
-				nvg::Scissor(pos.x, pos.y, valueWidth, size.y);
-			}
-			nvg::FillColor(Setting_Keyboard_FillColor);
-			nvg::Fill();
-			nvg::ResetScissor();
 		}
 
+		nvg::BeginPath();
+		SetNextShape(pos, size);
+		nvg::StrokeWidth(Setting_Keyboard_BorderWidth);
 		nvg::StrokeColor(borderColor);
 		nvg::Stroke();
 
@@ -70,6 +113,31 @@ class DashboardPadKeyboard : DashboardThing
 		nvg::FillColor(borderColor);
 		nvg::TextAlign(nvg::Align::Middle | nvg::Align::Center);
 		nvg::TextBox(pos.x, pos.y + size.y / 2, size.x, text);
+	}
+
+	void Update(float dt)
+	{
+		m_keyLeftAnimFactor = Math::Max(m_keyLeftAnimFactor - (dt / Setting_Keyboard_ReleaseAnimationLength), 0.0f);
+		m_keyRightAnimFactor = Math::Max(m_keyRightAnimFactor - (dt / Setting_Keyboard_ReleaseAnimationLength), 0.0f);
+		m_keyUpAnimFactor = Math::Max(m_keyUpAnimFactor - (dt / Setting_Keyboard_ReleaseAnimationLength), 0.0f);
+		m_keyDownAnimFactor = Math::Max(m_keyDownAnimFactor - (dt / Setting_Keyboard_ReleaseAnimationLength), 0.0f);
+	}
+
+	void SetNextShape(const vec2 &in pos, const vec2 &in size, float scaleFactor = 1.0f)
+	{
+		switch (Setting_Keyboard_Shape) {
+			case KeyboardShape::Rectangle:
+				nvg::RoundedRect(
+					pos.x + (0.5f * size.x * (1.0f - scaleFactor)),
+					pos.y + (0.5f * size.y * (1.0f - scaleFactor)),
+					size.x * scaleFactor,
+					size.y * scaleFactor,
+					Setting_Keyboard_BorderRadius);
+				break;
+			case KeyboardShape::Ellipse:
+				nvg::Ellipse(pos + size / 2.0f, size.x / 2 * scaleFactor, size.y / 2.0f * scaleFactor);
+				break;
+		}
 	}
 }
 #endif

--- a/Source/Settings.as
+++ b/Source/Settings.as
@@ -152,6 +152,20 @@ float Setting_Keyboard_Spacing = 10.0f;
 [Setting category="Keyboard" name="Inactive alpha" drag min=0 max=1]
 float Setting_Keyboard_InactiveAlpha = 0.4f;
 
+enum KeyboardAnimation
+{
+	None,
+	Shrink,
+	Fade,
+	ShrinkAndFade
+}
+
+[Setting category="Keyboard" name="Release Animation"]
+KeyboardAnimation Setting_Keyboard_ReleaseAnimation = KeyboardAnimation::None;
+
+[Setting category="Keyboard" name="Release Animation Length" drag min=50 max=500]
+float Setting_Keyboard_ReleaseAnimationLength = 150.0f;
+
 
 
 [Setting category="Gearbox" name="Show text"]

--- a/Source/Thing.as
+++ b/Source/Thing.as
@@ -14,4 +14,5 @@ class DashboardThing
 
 	void OnSettingsChanged() {}
 	void Render(CSceneVehicleVisState@ vis) {}
+	void Update(float dt) {}
 }


### PR DESCRIPTION
I'm opening this pull request so that you can take a look at these changes and decide if you like them.

Previously you were drawing just one shape for each key then changing it to either the active or inactive, and then applying the border. In order to have the animation show up in the right place, though, I had to break those out into separate steps each and draw them all. That is why I moved the `Setting_Keyboard_Shape` switch to the SetNextShape() method.

I used scale multipliers to apply my desired animation. Then in the Update() method I scale those down linearly to a min value of zero.

Do you think there would be value in implementing some other animation types besides linear?
Do you have any ideas for other things to animate?

I was going to start taking a look at possibly implementing this for gamepad gas/brake. Do you think it might make sense there?