### PR TITLE
Hide Dashboard when UISequence not "Playing"

### DIFF
--- a/Source/Dashboard.as
+++ b/Source/Dashboard.as
@@ -101,6 +101,14 @@ class Dashboard
 				}
 			}
 		}
+
+		if (Setting_General_HideWhenNotPlaying) {
+			if (app.CurrentPlayground !is null && (app.CurrentPlayground.UIConfigs.Length > 0)) {
+				if (app.CurrentPlayground.UIConfigs[0].UISequence != CGamePlaygroundUIConfig::EUISequence::Playing) {
+					return;
+				}
+			}
+		}
 #if !MP4
 		auto sceneVis = app.GameScene;
 		if (sceneVis is null) {

--- a/Source/Settings.as
+++ b/Source/Settings.as
@@ -13,6 +13,9 @@ ForcePadType Setting_General_ForcePadType = ForcePadType::None;
 [Setting category="General" name="Hide on hidden interface"]
 bool Setting_General_HideOnHiddenInterface = false;
 
+[Setting category="General" name="Hide during Intro sequences"]
+bool Setting_General_HideWhenNotPlaying = true;
+
 #if !COMPETITION
 [Setting category="General" name="Show controller/pad"]
 bool Setting_General_ShowPad = true;


### PR DESCRIPTION
Per #28, this setting hides the dashboard when the UISequence is not "Playing". This includes Intros, Outros, EndSequence, and Podium.
Tested in TMNext and MP4 both online and in local play.