### PR TITLE
Cateye style for Gamepad

### DIFF
--- a/Source/Pads/Gamepad.as
+++ b/Source/Pads/Gamepad.as
@@ -181,11 +181,135 @@ class DashboardPadGamepad : DashboardThing
 		nvg::ResetScissor();
 	}
 
+	void RenderCateye(CSceneVehicleVisState@ vis)
+	{
+		auto posLeft = vec2(0, m_size.y / 2);
+		auto posRight = vec2(m_size.x, m_size.y / 2);
+		auto posTop = vec2(m_size.x / 2, 0);
+		auto posBottom = vec2(m_size.x / 2, m_size.y);
+
+		float leftInflectionX = (m_size.x / 2) - (m_size.x / 2 * Setting_Gamepad_MiddleScale);
+		float midX_Left = (m_size.x / 2) - (m_size.x / 2 * Setting_Gamepad_MiddleScale * ((100.0f - Setting_Gamepad_Spacing) / 100.0f));
+		float midX_Right = (m_size.x / 2) + (m_size.x / 2 * Setting_Gamepad_MiddleScale * ((100.0f - Setting_Gamepad_Spacing) / 100.0f));
+		float rightInflectionX = (m_size.x / 2) + (m_size.x / 2 * Setting_Gamepad_MiddleScale);
+		float midY_Top = Setting_Gamepad_Spacing / 100.0f * m_size.y / 2;
+		float midY_Bot = m_size.y - midY_Top;
+		float midY_TopInflection = (m_size.y / 2) - ((((m_size.y / 2) - midY_Top) * 2) * Setting_Gamepad_ArrowPadding);
+		float midY_BotInflection = (m_size.y / 2) + ((((m_size.y / 2) - midY_Top) * 2) * Setting_Gamepad_ArrowPadding);
+
+		auto posLeftInflection = vec2(leftInflectionX, m_size.y / 2);
+		auto posRightInflection = vec2(rightInflectionX, m_size.y / 2);
+		auto posMidLeft = vec2(midX_Left, m_size.y / 2);
+		auto posMidRight = vec2(midX_Right, m_size.y / 2);
+		auto posMidTop = vec2(m_size.x / 2, midY_Top);
+		auto posMidBot = vec2(m_size.x / 2, midY_Bot);
+		auto posTopInflection = vec2(m_size.x / 2, midY_TopInflection);
+		auto posBotInflection = vec2(m_size.x / 2, midY_BotInflection);
+
+		bool validWidthCheckLeft = Math::Abs(posLeft.x - posLeftInflection.x) > 0.01f;
+		bool validWidthCheckRight = Math::Abs(posRight.x - posRightInflection.x) > 0.01f;
+		bool validHeightCheckTop = Math::Abs(posMidTop.y - posTopInflection.y) > 0.01f;
+		bool validHeightCheckBot = Math::Abs(posMidBot.y - posBotInflection.y) > 0.01f;
+		bool validWidthCheckMid = Math::Abs(posMidLeft.x - posMidRight.x) > 0.01f;
+
+		// Steering scales
+		float steerLeft = vis.InputSteer < 0 ? Math::Abs(vis.InputSteer) : 0.0f;
+		float steerRight = vis.InputSteer > 0 ? vis.InputSteer : 0.0f;
+		float pedalGas = vis.InputGasPedal;
+		float pedalBrake = vis.InputBrakePedal;
+
+		// It's possible that the brake pedal value is not set (eg. during replay playback), but we do
+		// have a binary value whether we're currently braking or not, so we use that to force the
+		// pedal value.
+		if (vis.InputIsBraking) {
+			pedalBrake = 1.0f;
+		}
+
+		// Left
+		if (validWidthCheckLeft) {
+			if (steerLeft > 0) {
+				auto v = vec2((m_size.x / 2) - steerLeft * (m_size.x / 2), 0);
+				nvg::FillPaint(nvg::LinearGradient(v - vec2(1, 0), v, Setting_Gamepad_EmptyFillColor, Setting_Gamepad_FillColor));
+			} else {
+				nvg::FillColor(Setting_Gamepad_EmptyFillColor);
+			}
+			nvg::BeginPath();
+			nvg::MoveTo(posLeft);
+			nvg::LineTo(posTop);
+			nvg::LineTo(posLeftInflection);
+			nvg::ClosePath();
+			nvg::Fill();
+			nvg::BeginPath();
+			nvg::MoveTo(posLeft);
+			nvg::LineTo(posBottom);
+			nvg::LineTo(posLeftInflection);
+			nvg::ClosePath();
+			nvg::Fill();
+		}
+
+		// Right
+		if (validWidthCheckRight) {
+			if (steerRight > 0) {
+				auto v = vec2((m_size.x / 2) + steerRight * (m_size.x / 2), 0);
+				nvg::FillPaint(nvg::LinearGradient(v, v + vec2(1, 0), Setting_Gamepad_FillColor, Setting_Gamepad_EmptyFillColor));
+			} else {
+				nvg::FillColor(Setting_Gamepad_EmptyFillColor);
+			}
+			nvg::BeginPath();
+			nvg::MoveTo(posRight);
+			nvg::LineTo(posTop);
+			nvg::LineTo(posRightInflection);
+			nvg::ClosePath();
+			nvg::Fill();
+			nvg::BeginPath();
+			nvg::MoveTo(posRight);
+			nvg::LineTo(posBottom);
+			nvg::LineTo(posRightInflection);
+			nvg::ClosePath();
+			nvg::Fill();
+		}
+
+		// Up
+		if (validWidthCheckMid && validHeightCheckTop) {
+			nvg::FillColor(pedalGas > 0.1f ? Setting_Gamepad_FillColor : Setting_Gamepad_EmptyFillColor);
+			nvg::BeginPath();
+			nvg::MoveTo(posMidTop);
+			nvg::LineTo(posMidLeft);
+			nvg::LineTo(posTopInflection);
+			nvg::ClosePath();
+			nvg::Fill();
+			nvg::BeginPath();
+			nvg::MoveTo(posMidTop);
+			nvg::LineTo(posMidRight);
+			nvg::LineTo(posTopInflection);
+			nvg::ClosePath();
+			nvg::Fill();
+		}
+
+		// Down
+		if (validWidthCheckMid && validHeightCheckBot) {
+			nvg::FillColor(pedalBrake > 0.1f ? Setting_Gamepad_FillColor : Setting_Gamepad_EmptyFillColor);
+			nvg::BeginPath();
+			nvg::MoveTo(posMidBot);
+			nvg::LineTo(posMidLeft);
+			nvg::LineTo(posBotInflection);
+			nvg::ClosePath();
+			nvg::Fill();
+			nvg::BeginPath();
+			nvg::MoveTo(posMidBot);
+			nvg::LineTo(posMidRight);
+			nvg::LineTo(posBotInflection);
+			nvg::ClosePath();
+			nvg::Fill();
+		}
+	}
+
 	void Render(CSceneVehicleVisState@ vis) override
 	{
 		switch (Setting_Gamepad_Style) {
 			case GamepadStyle::Uniform: RenderUniform(vis); break;
 			case GamepadStyle::Classic: RenderClassic(vis); break;
+			case GamepadStyle::Cateye: RenderCateye(vis); break;
 		}
 	}
 

--- a/Source/Settings.as
+++ b/Source/Settings.as
@@ -80,6 +80,7 @@ enum GamepadStyle
 {
 	Uniform,
 	Classic,
+	Cateye,
 }
 
 [Setting category="Gamepad" name="Style" description="Note: Not all styles use all customization options. Use Uniform for the best experience."]


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/52106022/135769355-9fde1cc4-fe9f-48ef-be31-8f5d3a2bb160.png)

This adds a new style of gamepad visualization per my interpretation of #33 .

During implementation I discovered that nanoVG does not want to fill a triangle with the one inflected edge, so I had to split each into two triangles.

For settings, I used the settings from Uniform with the exception of border color and size. I initially didnt want to duplicate a bunch of code to restroke the outlines for a border but if you think it's useful I can work on moving the path code to a function and stroke a border.