### PR TITLE
Add compact keyboard display

### DIFF
--- a/Source/Pads/Keyboard.as
+++ b/Source/Pads/Keyboard.as
@@ -7,19 +7,28 @@ class DashboardPadKeyboard : DashboardThing
 
 	void Render(CSceneVehicleVisState@ vis) override
 	{
-		auto keySize = vec2(
-			(m_size.x - Setting_Keyboard_Spacing * 2) / 3,
-			(m_size.y - Setting_Keyboard_Spacing) / 2
-		);
-
 		float steerLeft = vis.InputSteer < 0 ? Math::Abs(vis.InputSteer) : 0.0f;
 		float steerRight = vis.InputSteer > 0 ? vis.InputSteer : 0.0f;
 
-		RenderKey(vec2(keySize.x + Setting_Keyboard_Spacing, 0), keySize, Icons::AngleUp, vis.InputGasPedal);
-		RenderKey(vec2(keySize.x + Setting_Keyboard_Spacing, keySize.y + Setting_Keyboard_Spacing), keySize, Icons::AngleDown, vis.InputIsBraking ? 1.0f : vis.InputBrakePedal);
+		vec2 keySize = vec2((m_size.x - Setting_Keyboard_Spacing * 2) / 3, (m_size.y - Setting_Keyboard_Spacing) / 2);
+		vec2 sideKeySize = keySize;
 
-		RenderKey(vec2(0, keySize.y + Setting_Keyboard_Spacing), keySize, Icons::AngleLeft, steerLeft, -1);
-		RenderKey(vec2(keySize.x * 2 + Setting_Keyboard_Spacing * 2, keySize.y + Setting_Keyboard_Spacing), keySize, Icons::AngleRight, steerRight, 1);
+		vec2 upPos = vec2(keySize.x + Setting_Keyboard_Spacing, 0);
+		vec2 downPos = vec2(keySize.x + Setting_Keyboard_Spacing, keySize.y + Setting_Keyboard_Spacing);
+		vec2 leftPos = vec2(0, keySize.y + Setting_Keyboard_Spacing);
+		vec2 rightPos = vec2(keySize.x * 2 + Setting_Keyboard_Spacing * 2, keySize.y + Setting_Keyboard_Spacing);
+
+		if (Setting_Keyboard_Shape == KeyboardShape::Compact) {
+			sideKeySize.y = m_size.y;
+			leftPos.y = 0;
+			rightPos.y = 0;
+		}
+
+		RenderKey(upPos, keySize, Icons::AngleUp, vis.InputGasPedal);
+		RenderKey(downPos, keySize, Icons::AngleDown, vis.InputIsBraking ? 1.0f : vis.InputBrakePedal);
+
+		RenderKey(leftPos, sideKeySize, Icons::AngleLeft, steerLeft, -1);
+		RenderKey(rightPos, sideKeySize, Icons::AngleRight, steerRight, 1);
 	}
 
 	void RenderKey(const vec2 &in pos, const vec2 &in size, const string &in text, float value, int fillDir = 0)
@@ -35,8 +44,13 @@ class DashboardPadKeyboard : DashboardThing
 		nvg::StrokeWidth(Setting_Keyboard_BorderWidth);
 
 		switch (Setting_Keyboard_Shape) {
-			case KeyboardShape::Rectangle: nvg::RoundedRect(pos.x, pos.y, size.x, size.y, Setting_Keyboard_BorderRadius); break;
-			case KeyboardShape::Ellipse: nvg::Ellipse(pos + size / 2, size.x / 2, size.y / 2); break;
+			case KeyboardShape::Rectangle:
+			case KeyboardShape::Compact:
+				nvg::RoundedRect(pos.x, pos.y, size.x, size.y, Setting_Keyboard_BorderRadius);
+				break;
+			case KeyboardShape::Ellipse:
+				nvg::Ellipse(pos + size / 2, size.x / 2, size.y / 2);
+				break;
 		}
 
 		nvg::FillColor(Setting_Keyboard_EmptyFillColor);

--- a/Source/Settings.as
+++ b/Source/Settings.as
@@ -128,7 +128,7 @@ enum KeyboardShape
 {
 	Rectangle,
 	Ellipse,
-	Compact
+	Compact,
 }
 
 [Setting category="Keyboard" name="Shape"]

--- a/Source/Settings.as
+++ b/Source/Settings.as
@@ -128,6 +128,7 @@ enum KeyboardShape
 {
 	Rectangle,
 	Ellipse,
+	Compact
 }
 
 [Setting category="Keyboard" name="Shape"]


### PR DESCRIPTION
In this pull request I added a new display option for keyboard called "Compact". This display leaves the center keys untouched but makes the side keys take up the entire vertical size.
![image](https://user-images.githubusercontent.com/52106022/146103507-eca7a7ef-1a95-4c3c-a11c-8c511ffac82b.png)

To implement this I broke out all the inline `vec2`s for size and position into their own variables because it helps me comprehend the code.
All the calculations should be identical to before, the only real change I made was to add the conditional on line 22 of Keyboard.as that updates the side key vertical position and size when compact display is selected.

As always, I'm more than happy to make any changes you suggest.