### PR TITLE
Add new setting for gamepad text color (#69)

### DIFF
--- a/Source/Pads/Gamepad.as
+++ b/Source/Pads/Gamepad.as
@@ -98,7 +98,7 @@ class DashboardPadGamepad : IDashboardPad
 			nvg::BeginPath();
 			nvg::FontFace(g_font);
 			nvg::FontSize(midSize / 2);
-			nvg::FillColor(strokeColor);
+			nvg::FillColor(Setting_Gamepad_TextColor);
 			nvg::TextAlign(nvg::Align::Middle | nvg::Align::Center);
 			nvg::TextBox(midX, topSize / 2, midSize, Icons::AngleUp);
 			nvg::TextBox(midX, bottomY + bottomSize / 2, midSize, Icons::AngleDown);
@@ -108,7 +108,7 @@ class DashboardPadGamepad : IDashboardPad
 		if (Setting_Gamepad_SteerPercentage) {
 			nvg::FontFace(g_font);
 			nvg::FontSize(Setting_Gamepad_SteerPercentageSize);
-			nvg::FillColor(strokeColor);
+			nvg::FillColor(Setting_Gamepad_TextColor);
 
 			// Left
 			if (steerLeft > 0) {

--- a/Source/Settings.as
+++ b/Source/Settings.as
@@ -110,6 +110,9 @@ bool Setting_Gamepad_SteerPercentage = false;
 [Setting category="Gamepad" name="Steer percentage size" drag min=2 max=40]
 int Setting_Gamepad_SteerPercentageSize = 16;
 
+[Setting category="Gamepad" name="Text and symbol color" color]
+vec4 Setting_Gamepad_TextColor = vec4(1, 1, 1, 1);
+
 
 
 enum KeyboardShape


### PR DESCRIPTION
This adds a new option to the gamepad settings to configured text color. It affects both the steer percentage text as well as the up/down arrow text.