### PR TITLE
Clock widget

### DIFF
--- a/Source/Dashboard.as
+++ b/Source/Dashboard.as
@@ -9,6 +9,7 @@ class Dashboard
 		m_things.InsertLast(DashboardWheels());
 		m_things.InsertLast(DashboardAcceleration());
 		m_things.InsertLast(DashboardSpeed());
+		m_things.InsertLast(DashboardClock());
 	}
 
 	void Main()

--- a/Source/Settings.as
+++ b/Source/Settings.as
@@ -56,6 +56,15 @@ vec2 Setting_General_SpeedPos = vec2(0.909f, 0.4f);
 [Setting hidden]
 vec2 Setting_General_SpeedSize = vec2(230, 50);
 
+[Setting hidden]
+bool Setting_General_ShowClock = false;
+[Setting hidden]
+bool Setting_General_ShowClockHidden = false;
+[Setting hidden]
+vec2 Setting_General_ClockPos = vec2(0.906f, 0.48f);
+[Setting hidden]
+vec2 Setting_General_ClockSize = vec2(286, 50);
+
 
 
 enum GamepadStyle
@@ -425,3 +434,38 @@ string Setting_Wheels_DetailsFont = "DroidSans.ttf";
 
 [Setting category="Wheels" name="Details font size" drag min=0 max=100]
 float Setting_Wheels_DetailsFontSize = 16.0f;
+
+
+enum ClockIcon
+{
+	None,
+	Left,
+	Right,
+}
+
+[Setting category="Clock" name="Format"]
+string Setting_Clock_Format = "%F | %r";
+
+[Setting category="Clock" name="Clock icon"]
+ClockIcon Setting_Clock_Icon = ClockIcon::Right;
+
+[Setting category="Clock" name="Backdrop color" color]
+vec4 Setting_Clock_BackdropColor = vec4(0, 0, 0, 0.7f);
+
+[Setting category="Clock" name="Border color" color]
+vec4 Setting_Clock_BorderColor = vec4(1, 1, 1, 1);
+
+[Setting category="Clock" name="Text color" color]
+vec4 Setting_Clock_TextColor = vec4(1, 1, 1, 1);
+
+[Setting category="Clock" name="Border width" drag min=0 max=10]
+float Setting_Clock_BorderWidth = 3.0f;
+
+[Setting category="Clock" name="Border radius" drag min=0 max=50]
+float Setting_Clock_BorderRadius = 5.0f;
+
+[Setting category="Clock" name="Font"]
+string Setting_Clock_Font = "DroidSans.ttf";
+
+[Setting category="Clock" name="Font size" drag min=0 max=100]
+float Setting_Clock_FontSize = 20.0f;

--- a/Source/Things/Clock.as
+++ b/Source/Things/Clock.as
@@ -1,0 +1,82 @@
+class DashboardClock : DashboardThing
+{
+	nvg::Font m_font;
+	string m_fontPath;
+
+	DashboardClock()
+	{
+		super("Clock");
+		LoadFont();
+	}
+
+	bool IsVisible(bool whenHidden) override { return whenHidden ? Setting_General_ShowClockHidden : Setting_General_ShowClock; }
+	void SetVisible(bool visible, bool visibleWhenHidden) override
+	{
+		Setting_General_ShowClock = visible;
+		Setting_General_ShowClockHidden = visibleWhenHidden;
+	}
+
+	void UpdateProportions() override
+	{
+		m_pos = Setting_General_ClockPos;
+		m_size = Setting_General_ClockSize;
+	}
+
+	void SetProportions(const vec2 &in pos, const vec2 &in size) override
+	{
+		Setting_General_ClockPos = pos;
+		Setting_General_ClockSize = size;
+	}
+
+	void ResetProportions() override
+	{
+		auto plugin = Meta::ExecutingPlugin();
+		plugin.GetSetting("Setting_General_ClockPos").Reset();
+		plugin.GetSetting("Setting_General_ClockSize").Reset();
+	}
+
+	void LoadFont()
+	{
+		if (Setting_Clock_Font == m_fontPath) {
+			return;
+		}
+
+		auto font = nvg::LoadFont(Setting_Clock_Font, true);
+		if (font > 0) {
+			m_fontPath = Setting_Clock_Font;
+			m_font = font;
+		}
+	}
+
+	void OnSettingsChanged() override
+	{
+		LoadFont();
+	}
+
+	void Render(CSceneVehicleVisState@ vis) override
+	{
+		string clockTime = Time::FormatString(Setting_Clock_Format);
+		switch (Setting_Clock_Icon) {
+			case ClockIcon::Left: clockTime = Icons::ClockO + " " + clockTime; break;
+			case ClockIcon::Right: clockTime = clockTime + " " + Icons::ClockO; break;
+		}
+
+		nvg::BeginPath();
+		nvg::RoundedRect(0, 0, m_size.x, m_size.y, Setting_Clock_BorderRadius);
+
+		nvg::FillColor(Setting_Clock_BackdropColor);
+		nvg::Fill();
+
+		nvg::StrokeColor(Setting_Clock_BorderColor);
+		nvg::StrokeWidth(Setting_Clock_BorderWidth);
+		nvg::Stroke();
+
+		nvg::BeginPath();
+		nvg::FontFace(m_font);
+		nvg::FontSize(Setting_Clock_FontSize);
+		nvg::FillColor(Setting_Clock_TextColor);
+
+		nvg::TextAlign(nvg::Align::Middle | nvg::Align::Center);
+		nvg::TextBox(0, m_size.y / 2, m_size.x, clockTime);
+	}
+}


### PR DESCRIPTION
This merge request adds a simple clock widget. It is loosely based on the Clock plugin for Openplanet. The advantage over the standalone Clock plugin is the ability to position and customize the clock like any other Dashboard widget and to glance at the time without having to (keep) open the Openplanet overlay.

Tested on Maniaplanet 4 (TM2 Canyon).