### PR TITLE
Clock widget modes

### DIFF
--- a/Source/Settings.as
+++ b/Source/Settings.as
@@ -436,6 +436,13 @@ string Setting_Wheels_DetailsFont = "DroidSans.ttf";
 float Setting_Wheels_DetailsFontSize = 16.0f;
 
 
+enum ClockMode
+{
+	LocalTime,
+	UTCTime,
+	SessionTime,
+}
+
 enum ClockIcon
 {
 	None,
@@ -443,8 +450,14 @@ enum ClockIcon
 	Right,
 }
 
+[Setting category="Clock" name="Mode"]
+ClockMode Setting_Clock_Mode = ClockMode::LocalTime;
+
 [Setting category="Clock" name="Format"]
 string Setting_Clock_Format = "%F | %r";
+
+[Setting category="Clock" name="Fractions (Session Time only)"]
+bool Setting_Clock_Fractions = false;
 
 [Setting category="Clock" name="Clock icon"]
 ClockIcon Setting_Clock_Icon = ClockIcon::Right;

--- a/Source/Settings.as
+++ b/Source/Settings.as
@@ -440,7 +440,6 @@ enum ClockMode
 {
 	LocalTime,
 	UTCTime,
-	SessionTime,
 }
 
 enum ClockIcon
@@ -455,9 +454,6 @@ ClockMode Setting_Clock_Mode = ClockMode::LocalTime;
 
 [Setting category="Clock" name="Format"]
 string Setting_Clock_Format = "%F | %r";
-
-[Setting category="Clock" name="Fractions (Session Time only)"]
-bool Setting_Clock_Fractions = false;
 
 [Setting category="Clock" name="Clock icon"]
 ClockIcon Setting_Clock_Icon = ClockIcon::Right;

--- a/Source/Things/Clock.as
+++ b/Source/Things/Clock.as
@@ -60,7 +60,6 @@ class DashboardClock : DashboardThing
 		switch (Setting_Clock_Mode){
 			case ClockMode::LocalTime: clockTime = Time::FormatString(Setting_Clock_Format); break;
 			case ClockMode::UTCTime: clockTime = Time::FormatStringUTC(Setting_Clock_Format); break;
-			case ClockMode::SessionTime: clockTime = Time::Format(Time::get_Now(), Setting_Clock_Fractions); break;
 		}
 
 		switch (Setting_Clock_Icon) {

--- a/Source/Things/Clock.as
+++ b/Source/Things/Clock.as
@@ -55,7 +55,14 @@ class DashboardClock : DashboardThing
 
 	void Render(CSceneVehicleVisState@ vis) override
 	{
-		string clockTime = Time::FormatString(Setting_Clock_Format);
+		string clockTime;
+
+		switch (Setting_Clock_Mode){
+			case ClockMode::LocalTime: clockTime = Time::FormatString(Setting_Clock_Format); break;
+			case ClockMode::UTCTime: clockTime = Time::FormatStringUTC(Setting_Clock_Format); break;
+			case ClockMode::SessionTime: clockTime = Time::Format(Time::get_Now(), Setting_Clock_Fractions); break;
+		}
+
 		switch (Setting_Clock_Icon) {
 			case ClockIcon::Left: clockTime = Icons::ClockO + " " + clockTime; break;
 			case ClockIcon::Right: clockTime = clockTime + " " + Icons::ClockO; break;


### PR DESCRIPTION
This merge request adds game session time as an option for the clock widget, plus local/UTC time options.

Screenshot:
![2023-09-17_16-30-33](https://github.com/codecat/tm-dashboard/assets/33978534/7bf78e17-aa52-45c8-b06c-4e0f82976c05)
