### PR TITLE
Add exported function so another plugin can inform dashboard of the current vehicles entity ID

### DIFF
--- a/Source/Dashboard.as
+++ b/Source/Dashboard.as
@@ -42,6 +42,18 @@ class Dashboard
 		}
 
 		auto visState = VehicleState::ViewingPlayerState();
+		// If we didn't find a vis state, use the vehicle entity ID provided by another plugin if it is recent
+		if (visState is null && g_InformedCurrentEntId > 0 && Time::Now - g_InformedCurrentEntIdLastAt < 100 && app.GameScene !is null) {
+			array<CSceneVehicleVis@>@ allVis = VehicleState::GetAllVis(app.GameScene);
+			CSceneVehicleVis@ vis;
+			for (uint i = 0; i < allVis.Length; i++) {
+				@vis = allVis[i];
+				if (vis !is null && Dev::GetOffsetUint32(vis, 0x0) == g_InformedCurrentEntId) {
+					@visState = vis.AsyncState;
+					break;
+				}
+			}
+		}
 		if (visState is null) {
 			return;
 		}

--- a/Source/Exports.as
+++ b/Source/Exports.as
@@ -1,0 +1,4 @@
+namespace Dashboard
+{
+	import void InformCurrentEntityId(uint EntId) from "Dashboard";
+}

--- a/Source/Exports_Impl.as
+++ b/Source/Exports_Impl.as
@@ -1,0 +1,10 @@
+uint g_InformedCurrentEntId;
+uint g_InformedCurrentEntIdLastAt;
+
+namespace Dashboard
+{
+	void InformCurrentEntityId(uint EntId) {
+        g_InformedCurrentEntId = EntId;
+        g_InformedCurrentEntIdLastAt = Time::Now;
+    }
+}

--- a/info.toml
+++ b/info.toml
@@ -9,3 +9,4 @@ blocks = [ "Plugin_Dashboard" ]
 [script]
 dependencies = [ "VehicleState" ]
 timeout = 0
+exports = ["Source/Exports.as"]


### PR DESCRIPTION
This will allow Ghosts++ to inform Dashboard of the current vehicle entity ID so inputs are shown with all dashboard widgets & users settings are respected.