### PR TITLE
Displaying the ground surface on the wheels display

### DIFF
--- a/Source/Settings.as
+++ b/Source/Settings.as
@@ -435,6 +435,17 @@ string Setting_Wheels_DetailsFont = "DroidSans.ttf";
 [Setting category="Wheels" name="Details font size" drag min=0 max=100]
 float Setting_Wheels_DetailsFontSize = 16.0f;
 
+[Setting category="Wheels" name="Ice Surface Color" color]
+vec3 Setting_Wheels_IceSurfaceColor = vec3(0.6f, 1, 0.95f);
+
+[Setting category="Wheels" name="Boost Surface Color" color]
+vec3 Setting_Wheels_BoostSurfaceColor = vec3(1, 1, 0);
+
+[Setting category="Wheels" name="Grass Surface Color" color]
+vec3 Setting_Wheels_GrassSurfaceColor = vec3(0, 1, 0);
+
+[Setting category="Wheels" name="Dirt Surface Color" color]
+vec3 Setting_Wheels_DirtSurfaceColor = vec3(0.8f, 0.5f, 0);
 
 enum ClockMode
 {

--- a/Source/Settings.as
+++ b/Source/Settings.as
@@ -435,17 +435,29 @@ string Setting_Wheels_DetailsFont = "DroidSans.ttf";
 [Setting category="Wheels" name="Details font size" drag min=0 max=100]
 float Setting_Wheels_DetailsFontSize = 16.0f;
 
+[Setting category="Wheels" name="Show wheel surface"]
+bool Setting_Wheels_WheelSurface = false;
+
 [Setting category="Wheels" name="Ice Surface Color" color]
 vec3 Setting_Wheels_IceSurfaceColor = vec3(0.6f, 1, 0.95f);
-
-[Setting category="Wheels" name="Boost Surface Color" color]
-vec3 Setting_Wheels_BoostSurfaceColor = vec3(1, 1, 0);
 
 [Setting category="Wheels" name="Grass Surface Color" color]
 vec3 Setting_Wheels_GrassSurfaceColor = vec3(0, 1, 0);
 
 [Setting category="Wheels" name="Dirt Surface Color" color]
 vec3 Setting_Wheels_DirtSurfaceColor = vec3(0.8f, 0.5f, 0);
+
+[Setting category="Wheels" name="Wood Surface Color" color]
+vec3 Setting_Wheels_WoodSurfaceColor = vec3(0.3f, 0.1f, 0);
+
+[Setting category="Wheels" name="Plastic Surface Color" color]
+vec3 Setting_Wheels_PlasticSurfaceColor = vec3(0.5f, 0, 0);
+
+[Setting category="Wheels" name="Snow Surface Color" color]
+vec3 Setting_Wheels_SnowSurfaceColor = vec3(0.7f, 1, 1);
+
+[Setting category="Wheels" name="Sand Surface Color" color]
+vec3 Setting_Wheels_SandSurfaceColor = vec3(1, 1, 0);
 
 enum ClockMode
 {

--- a/Source/Things/Wheels.as
+++ b/Source/Things/Wheels.as
@@ -102,7 +102,7 @@ class DashboardWheels : DashboardThing
 				ret.m_breakCoef = vis.FRBreakNormedCoef;
 				ret.m_tireWear = vis.FRTireWear01;
 				ret.m_icing = vis.FRIcing01;
-				ret.m_groundMaterial = vis.FLGroundContactMaterial;
+				ret.m_groundMaterial = vis.FRGroundContactMaterial;
 #endif
 				break;
 			case WheelType::RL:
@@ -141,18 +141,31 @@ class DashboardWheels : DashboardThing
 		return ret;
 	}
 
-	vec3 GetWheelGroundColor(const WheelState& state) {
+	vec3 GetWheelSurfaceColor(const WheelState& state) {
 		vec3 ret(0,0,0);
 		switch (state.m_groundMaterial) {
 			case EPlugSurfaceMaterialId::Ice:
+			case EPlugSurfaceMaterialId::RoadIce:
 				ret = Setting_Wheels_IceSurfaceColor;
 				break;
 			case EPlugSurfaceMaterialId::Grass:
+			case EPlugSurfaceMaterialId::Green:
 				ret = Setting_Wheels_GrassSurfaceColor;
 				break;
 			case EPlugSurfaceMaterialId::Dirt:
 				ret = Setting_Wheels_DirtSurfaceColor;
 				break;
+			case EPlugSurfaceMaterialId::Wood:
+				ret = Setting_Wheels_WoodSurfaceColor;
+				break;
+			case EPlugSurfaceMaterialId::Plastic:
+				ret = Setting_Wheels_PlasticSurfaceColor;
+				break;
+			case EPlugSurfaceMaterialId::Snow:
+				ret = Setting_Wheels_SnowSurfaceColor;
+				break;
+			case EPlugSurfaceMaterialId::Sand:
+				ret = Setting_Wheels_SandSurfaceColor;
 		}
 		return ret;
 	}
@@ -203,10 +216,12 @@ class DashboardWheels : DashboardThing
 			const float lineHeight = 7;
 			const float lineSpacing = 5;
 			int numLines = int(size.y / (lineHeight + lineSpacing)) + 1;
-
 			nvg::Scissor(pos.x, pos.y, size.x, size.y);
-			vec3 color = GetWheelGroundColor(state);
-			nvg::FillColor(vec4(color[0], color[1], color[2], Setting_Wheels_WheelMotionAlpha));
+			vec3 surfaceColor(0,0,0);
+#if TMNEXT
+			surfaceColor = Setting_Wheels_WheelSurface ? GetWheelSurfaceColor(state) : vec3(0,0,0);
+#endif
+			nvg::FillColor(vec4(surfaceColor.x, surfaceColor.y, surfaceColor.z, Setting_Wheels_WheelMotionAlpha));
 			for (int i = -1; i < numLines; i++) {
 				float offset = i * (lineHeight + lineSpacing);
 				offset = Math::Round(offset + ((state.m_rot * Setting_Wheels_MotionScale) % (lineHeight + lineSpacing)));

--- a/Source/Things/Wheels.as
+++ b/Source/Things/Wheels.as
@@ -217,9 +217,10 @@ class DashboardWheels : DashboardThing
 			const float lineSpacing = 5;
 			int numLines = int(size.y / (lineHeight + lineSpacing)) + 1;
 			nvg::Scissor(pos.x, pos.y, size.x, size.y);
-			vec3 surfaceColor(0,0,0);
 #if TMNEXT
-			surfaceColor = Setting_Wheels_WheelSurface ? GetWheelSurfaceColor(state) : vec3(0,0,0);
+			vec3 surfaceColor = Setting_Wheels_WheelSurface ? GetWheelSurfaceColor(state) : vec3(0,0,0);
+#else
+			vec3 surfaceColor(0,0,0);
 #endif
 			nvg::FillColor(vec4(surfaceColor.x, surfaceColor.y, surfaceColor.z, Setting_Wheels_WheelMotionAlpha));
 			for (int i = -1; i < numLines; i++) {

--- a/Source/Things/Wheels.as
+++ b/Source/Things/Wheels.as
@@ -16,6 +16,7 @@ class WheelState
 	float m_tireWear;
 	float m_icing;
 	float m_wetness;
+	EPlugSurfaceMaterialId m_groundMaterial;
 #endif
 }
 
@@ -88,6 +89,7 @@ class DashboardWheels : DashboardThing
 				ret.m_breakCoef = vis.FLBreakNormedCoef;
 				ret.m_tireWear = vis.FLTireWear01;
 				ret.m_icing = vis.FLIcing01;
+				ret.m_groundMaterial = vis.FLGroundContactMaterial;
 #endif
 				break;
 			case WheelType::FR:
@@ -100,6 +102,7 @@ class DashboardWheels : DashboardThing
 				ret.m_breakCoef = vis.FRBreakNormedCoef;
 				ret.m_tireWear = vis.FRTireWear01;
 				ret.m_icing = vis.FRIcing01;
+				ret.m_groundMaterial = vis.FLGroundContactMaterial;
 #endif
 				break;
 			case WheelType::RL:
@@ -112,6 +115,7 @@ class DashboardWheels : DashboardThing
 				ret.m_breakCoef = vis.RLBreakNormedCoef;
 				ret.m_tireWear = vis.RLTireWear01;
 				ret.m_icing = vis.RLIcing01;
+				ret.m_groundMaterial = vis.RLGroundContactMaterial;
 #endif
 				break;
 			case WheelType::RR:
@@ -124,6 +128,7 @@ class DashboardWheels : DashboardThing
 				ret.m_breakCoef = vis.RRBreakNormedCoef;
 				ret.m_tireWear = vis.RRTireWear01;
 				ret.m_icing = vis.RRIcing01;
+				ret.m_groundMaterial = vis.RRGroundContactMaterial;
 #endif
 				break;
 		}
@@ -133,6 +138,22 @@ class DashboardWheels : DashboardThing
 		ret.m_wetness = vis.WetnessValue01;
 #endif
 
+		return ret;
+	}
+
+	vec3 GetWheelGroundColor(const WheelState& state) {
+		vec3 ret(0,0,0);
+		switch (state.m_groundMaterial) {
+			case EPlugSurfaceMaterialId::Ice:
+				ret = Setting_Wheels_IceSurfaceColor;
+				break;
+			case EPlugSurfaceMaterialId::Grass:
+				ret = Setting_Wheels_GrassSurfaceColor;
+				break;
+			case EPlugSurfaceMaterialId::Dirt:
+				ret = Setting_Wheels_DirtSurfaceColor;
+				break;
+		}
 		return ret;
 	}
 
@@ -184,7 +205,8 @@ class DashboardWheels : DashboardThing
 			int numLines = int(size.y / (lineHeight + lineSpacing)) + 1;
 
 			nvg::Scissor(pos.x, pos.y, size.x, size.y);
-			nvg::FillColor(vec4(0, 0, 0, Setting_Wheels_WheelMotionAlpha));
+			vec3 color = GetWheelGroundColor(state);
+			nvg::FillColor(vec4(color[0], color[1], color[2], Setting_Wheels_WheelMotionAlpha));
 			for (int i = -1; i < numLines; i++) {
 				float offset = i * (lineHeight + lineSpacing);
 				offset = Math::Round(offset + ((state.m_rot * Setting_Wheels_MotionScale) % (lineHeight + lineSpacing)));

--- a/Source/Things/Wheels.as
+++ b/Source/Things/Wheels.as
@@ -141,8 +141,10 @@ class DashboardWheels : DashboardThing
 		return ret;
 	}
 
-	vec3 GetWheelSurfaceColor(const WheelState& state) {
+	vec3 GetWheelSurfaceColor(const WheelState& state) 
+	{
 		vec3 ret(0,0,0);
+
 		switch (state.m_groundMaterial) {
 			case EPlugSurfaceMaterialId::Ice:
 			case EPlugSurfaceMaterialId::RoadIce:
@@ -167,6 +169,7 @@ class DashboardWheels : DashboardThing
 			case EPlugSurfaceMaterialId::Sand:
 				ret = Setting_Wheels_SandSurfaceColor;
 		}
+
 		return ret;
 	}
 


### PR DESCRIPTION
## Description
What used to be the WheelMotions in the wheels display changes color to indicate the surface you're driving on. By default, this feature is deactivated in the settings.

## Related Issue
This change was made for the issue #49.

## Changes made
 - One tickable and seven color settings for the configurations of the colors in [Source/Settings.as](https://github.com/codecat/tm-dashboard/compare/master...itsKorzie:tm-dashboard:master#diff-2d4ec8383742d09ad2ba035001024a89b65223e980ec5960b9acd1ee15f547b5)
 - Added `m_groundMaterial` to `WheelState`
 - Added function `vec3 GetWheelSurfaceColor(const WheelState& state)` to retrieve the color from a surface
 - Changed the fillColor of the pencil when drawing the wheelMotions

## Screenshots
![image](https://github.com/codecat/tm-dashboard/assets/63919848/006ff020-26ee-4445-9fb6-d28cd005e738)
![image](https://github.com/codecat/tm-dashboard/assets/63919848/1e3fb6f9-42f1-4251-af7e-bcd59c7d683e)