### PR TITLE
Add font size for gearbox

### DIFF
--- a/Source/Settings.as
+++ b/Source/Settings.as
@@ -240,6 +240,9 @@ vec4 Setting_Gearbox_TextColor = vec4(1, 1, 1, 1);
 [Setting category="Gearbox" name="Font" if="Setting_Gearbox_ShowText"]
 string Setting_Gearbox_Font = "DroidSans.ttf";
 
+[Setting category="Gearbox" name="Font size" drag min=0 max=100 if="Setting_Gearbox_ShowText"]
+float Setting_Gearbox_FontSize = 24.0f;
+
 [Setting category="Gearbox" name="Use gear colors"]
 bool Setting_Gearbox_UseGearColors = false;
 

--- a/Source/Things/Gearbox.as
+++ b/Source/Things/Gearbox.as
@@ -99,7 +99,7 @@ class DashboardGearbox : DashboardThing
 		}
 
 		nvg::BeginPath();
-		nvg::FontSize(24);
+		nvg::FontSize(Setting_Gearbox_FontSize);
 		nvg::TextBox(0, size.y * gearY, size.x, "" + gear);
 
 		if (Setting_Gearbox_ShowRPMText) {


### PR DESCRIPTION
This adds a setting to adjust the font size of the gear in the gearbox.

It would be a huge help in making the game more accessible to visually impaired people like me. 
As this is my first experience working on a TM plugin, please let me know, if it needs any changes.