### PR TITLE
input display stuff

### DIFF
--- a/Source/Pads/Gamepad.as
+++ b/Source/Pads/Gamepad.as
@@ -1,5 +1,31 @@
 class DashboardPadGamepad : IDashboardPad
 {
+	nvg::Font m_font;
+	string m_fontPath;
+
+	DashboardPadGamepad()
+	{
+		LoadFont();
+	}
+
+	void LoadFont()
+	{
+		if (Setting_Gamepad_Font == m_fontPath) {
+			return;
+		}
+
+		auto font = nvg::LoadFont(Setting_Gamepad_Font);
+		if (font >= 0) {
+			m_fontPath = Setting_Gamepad_Font;
+			m_font = font;
+		}
+	}
+
+	void OnSettingsChanged() override
+	{
+		LoadFont();
+	}
+
 	void RenderUniform(const vec2 &in size, CSceneVehicleVisState@ vis)
 	{
 		float leftSize = size.x * (0.5f - Setting_Gamepad_MiddleScale / 2) - Setting_Gamepad_Spacing;
@@ -123,7 +149,7 @@ class DashboardPadGamepad : IDashboardPad
 
 		// Steering percentage
 		if (Setting_Gamepad_SteerPercentage) {
-			nvg::FontFace(g_font);
+			nvg::FontFace(m_font);
 			nvg::FontSize(Setting_Gamepad_SteerPercentageSize);
 			nvg::FillColor(Setting_Gamepad_TextColor);
 

--- a/Source/Pads/Gamepad.as
+++ b/Source/Pads/Gamepad.as
@@ -72,9 +72,9 @@ class DashboardPadGamepad : IDashboardPad
 			nvg::Fill();
 			nvg::ResetScissor();
 		}
-		float fillAlpha = Math::Lerp(Setting_Gamepad_OffAlpha, 1.0f, steerLeft);
+		float fillAlphaLeft = Math::Lerp(Setting_Gamepad_OffAlpha, 1.0f, steerLeft);
 		if (Setting_Gamepad_UseBorderGradient) {
-			nvg::StrokePaint(Setting_Gamepad_BorderGradient.GetPaint(vec2(), size, fillAlpha));
+			nvg::StrokePaint(Setting_Gamepad_BorderGradient.GetPaint(vec2(), size, fillAlphaLeft));
 		} else {
 			nvg::StrokeColor(Setting_Gamepad_BorderColor);
 		}
@@ -99,9 +99,9 @@ class DashboardPadGamepad : IDashboardPad
 			nvg::Fill();
 			nvg::ResetScissor();
 		}
-		fillAlpha = Math::Lerp(Setting_Gamepad_OffAlpha, 1.0f, steerRight);
+		float fillAlphaRight = Math::Lerp(Setting_Gamepad_OffAlpha, 1.0f, steerRight);
 		if (Setting_Gamepad_UseBorderGradient) {
-			nvg::StrokePaint(Setting_Gamepad_BorderGradient.GetPaint(vec2(), size, fillAlpha));
+			nvg::StrokePaint(Setting_Gamepad_BorderGradient.GetPaint(vec2(), size, fillAlphaRight));
 		} else {
 			nvg::StrokeColor(Setting_Gamepad_BorderColor);
 		}
@@ -123,9 +123,9 @@ class DashboardPadGamepad : IDashboardPad
 			nvg::Fill();
 			nvg::ResetScissor();
 		}
-		fillAlpha = pedalGas > 0.1f ? 1.0f : Setting_Gamepad_OffAlpha;
+		float fillAlphaUp = pedalGas > 0.1f ? 1.0f : Setting_Gamepad_OffAlpha;
 		if (Setting_Gamepad_UseBorderGradient) {
-			nvg::StrokePaint(Setting_Gamepad_BorderGradient.GetPaint(vec2(), size, fillAlpha));
+			nvg::StrokePaint(Setting_Gamepad_BorderGradient.GetPaint(vec2(), size, fillAlphaUp));
 		} else {
 			nvg::StrokeColor(Setting_Gamepad_BorderColor);
 		}
@@ -147,9 +147,9 @@ class DashboardPadGamepad : IDashboardPad
 			nvg::Fill();
 			nvg::ResetScissor();
 		}
-		fillAlpha = pedalBrake > 0.1f ? 1.0f : Setting_Gamepad_OffAlpha;
+		float fillAlphaDown = pedalBrake > 0.1f ? 1.0f : Setting_Gamepad_OffAlpha;
 		if (Setting_Gamepad_UseBorderGradient) {
-			nvg::StrokePaint(Setting_Gamepad_BorderGradient.GetPaint(vec2(), size, fillAlpha));
+			nvg::StrokePaint(Setting_Gamepad_BorderGradient.GetPaint(vec2(), size, fillAlphaDown));
 		} else {
 			nvg::StrokeColor(Setting_Gamepad_BorderColor);
 		}
@@ -160,9 +160,10 @@ class DashboardPadGamepad : IDashboardPad
 			nvg::BeginPath();
 			nvg::FontFace(m_font);
 			nvg::FontSize(Setting_Gamepad_FontSize * 1.5f);
-			nvg::FillColor(Setting_Gamepad_FontColor);
 			nvg::TextAlign(nvg::Align::Middle | nvg::Align::Center);
+			nvg::FillColor(WithAlpha(Setting_Gamepad_FontColor, fillAlphaUp));
 			nvg::TextBox(midX, topSize / 2, midSize, Icons::AngleUp);
+			nvg::FillColor(WithAlpha(Setting_Gamepad_FontColor, fillAlphaDown));
 			nvg::TextBox(midX, bottomY + bottomSize / 2, midSize, Icons::AngleDown);
 		}
 
@@ -170,12 +171,12 @@ class DashboardPadGamepad : IDashboardPad
 		if (Setting_Gamepad_SteerPercentage) {
 			nvg::FontFace(m_font);
 			nvg::FontSize(Setting_Gamepad_FontSize);
-			nvg::FillColor(Setting_Gamepad_FontColor);
 
 			// Left
 			if (steerLeft > 0) {
 				nvg::BeginPath();
 				nvg::TextAlign(nvg::Align::Middle | nvg::Align::Right);
+				nvg::FillColor(WithAlpha(Setting_Gamepad_FontColor, fillAlphaLeft));
 				nvg::TextBox(
 					-Setting_Gamepad_SteerPercentageSpacing,
 					size.y / 2,
@@ -188,6 +189,7 @@ class DashboardPadGamepad : IDashboardPad
 			if (steerRight > 0) {
 				nvg::BeginPath();
 				nvg::TextAlign(nvg::Align::Middle | nvg::Align::Left);
+				nvg::FillColor(WithAlpha(Setting_Gamepad_FontColor, fillAlphaRight));
 				nvg::TextBox(
 					Setting_Gamepad_SteerPercentageSpacing + rightX + Setting_Gamepad_Spacing,
 					size.y / 2,

--- a/Source/Pads/Gamepad.as
+++ b/Source/Pads/Gamepad.as
@@ -157,14 +157,14 @@ class DashboardPadGamepad : IDashboardPad
 			if (steerLeft > 0) {
 				nvg::BeginPath();
 				nvg::TextAlign(nvg::Align::Middle | nvg::Align::Right);
-				nvg::TextBox(0, size.y / 2, leftSize - Setting_Gamepad_Spacing, tostring(Math::Round(steerLeft * 100)) + "%");
+				nvg::TextBox(0, size.y / 2, leftSize - Setting_Gamepad_Spacing, Text::Format("%.f%%", steerLeft * 100.0f));
 			}
 
 			// Right
 			if (steerRight > 0) {
 				nvg::BeginPath();
 				nvg::TextAlign(nvg::Align::Middle | nvg::Align::Left);
-				nvg::TextBox(rightX + Setting_Gamepad_Spacing, size.y / 2, rightSize, tostring(Math::Round(steerRight * 100)) + "%");
+				nvg::TextBox(rightX + Setting_Gamepad_Spacing, size.y / 2, rightSize, Text::Format("%.f%%", steerRight * 100.0f));
 			}
 		}
 	}

--- a/Source/Pads/Gamepad.as
+++ b/Source/Pads/Gamepad.as
@@ -348,6 +348,8 @@ class DashboardPadGamepad : IDashboardPad
 		vec2 posTopInflection = vec2(size.x / 2, midY_TopInflection);
 		vec2 posBotInflection = vec2(size.x / 2, midY_BotInflection);
 
+		nvg::Paint fillPaint = Setting_Gamepad_FillGradient.GetPaint(vec2(), size);
+
 		// Left
 		if (Setting_Gamepad_CateyeUseSimpleSteer && steerLeft > 0) {
 			auto v = vec2((size.x / 2) - steerLeft * (size.x / 2), 0);
@@ -357,7 +359,11 @@ class DashboardPadGamepad : IDashboardPad
 		}
 		FillInflectedTriangle(posLeft, posLeftInflection, posTop, posBottom);
 		if (!Setting_Gamepad_CateyeUseSimpleSteer) {
-			nvg::FillColor(Setting_Gamepad_FillColor);
+			if (Setting_Gamepad_UseFillGradient) {
+				nvg::FillPaint(fillPaint);
+			} else {
+				nvg::FillColor(Setting_Gamepad_FillColor);
+			}
 			FillInflectedTriangle(posLeftSteer, posLeftInflection, posTop, posBottom);
 		}
 		float fillAlphaLeft = Math::Lerp(Setting_Gamepad_OffAlpha, 1.0f, steerLeft);
@@ -377,7 +383,11 @@ class DashboardPadGamepad : IDashboardPad
 		}
 		FillInflectedTriangle(posRight, posRightInflection, posTop, posBottom);
 		if (!Setting_Gamepad_CateyeUseSimpleSteer) {
-			nvg::FillColor(Setting_Gamepad_FillColor);
+			if (Setting_Gamepad_UseFillGradient) {
+				nvg::FillPaint(fillPaint);
+			} else {
+				nvg::FillColor(Setting_Gamepad_FillColor);
+			}
 			FillInflectedTriangle(posRightSteer, posRightInflection, posTop, posBottom);
 		}
 		float fillAlphaRight = Math::Lerp(Setting_Gamepad_OffAlpha, 1.0f, steerRight);
@@ -389,7 +399,15 @@ class DashboardPadGamepad : IDashboardPad
 		StrokeInflectedTriangle(posRight, posRightInflection, posTop, posBottom);
 
 		// Up
-		nvg::FillColor(pedalGas > 0.1f ? Setting_Gamepad_FillColor : Setting_Gamepad_EmptyFillColor);
+		if (pedalGas > 0.1f) {
+			if (Setting_Gamepad_UseFillGradient) {
+				nvg::FillPaint(fillPaint);
+			} else {
+				nvg::FillColor(Setting_Gamepad_FillColor);
+			}
+		} else {
+			nvg::FillColor(Setting_Gamepad_EmptyFillColor);
+		}
 		FillInflectedTriangle(posMidTop, posTopInflection, posMidLeft, posMidRight);
 		float fillAlphaUp = pedalGas > 0.1f ? 1.0f : Setting_Gamepad_OffAlpha;
 		if (Setting_Gamepad_UseBorderGradient) {
@@ -400,7 +418,15 @@ class DashboardPadGamepad : IDashboardPad
 		StrokeInflectedTriangle(posMidTop, posTopInflection, posMidLeft, posMidRight);
 
 		// Down
-		nvg::FillColor(pedalBrake > 0.1f ? Setting_Gamepad_FillColor : Setting_Gamepad_EmptyFillColor);
+		if (pedalBrake > 0.1f) {
+			if (Setting_Gamepad_UseFillGradient) {
+				nvg::FillPaint(fillPaint);
+			} else {
+				nvg::FillColor(Setting_Gamepad_FillColor);
+			}
+		} else {
+			nvg::FillColor(Setting_Gamepad_EmptyFillColor);
+		}
 		FillInflectedTriangle(posMidBot, posBotInflection, posMidLeft, posMidRight);
 		float fillAlphaDown = pedalBrake > 0.1f ? 1.0f : Setting_Gamepad_OffAlpha;
 		if (Setting_Gamepad_UseBorderGradient) {

--- a/Source/Pads/Gamepad.as
+++ b/Source/Pads/Gamepad.as
@@ -257,6 +257,27 @@ class DashboardPadGamepad : IDashboardPad
 		nvg::FillColor(WithAlpha(Setting_Gamepad_ClassicDownColor, pedalBrake > 0.1f ? 1.0f : Setting_Gamepad_OffAlpha));
 		nvg::Fill();
 		nvg::ResetScissor();
+
+		// Steering percentage
+		if (Setting_Gamepad_SteerPercentage) {
+			nvg::FontFace(m_font);
+			nvg::FontSize(Setting_Gamepad_FontSize);
+			nvg::FillColor(Setting_Gamepad_FontColor);
+
+			// Left
+			if (steerLeft > 0) {
+				nvg::BeginPath();
+				nvg::TextAlign(nvg::Align::Middle | nvg::Align::Right);
+				nvg::TextBox(0, size.y / 2, leftSize - Setting_Gamepad_Spacing, Text::Format("%.f%%", steerLeft * 100.0f));
+			}
+
+			// Right
+			if (steerRight > 0) {
+				nvg::BeginPath();
+				nvg::TextAlign(nvg::Align::Middle | nvg::Align::Left);
+				nvg::TextBox(rightX + Setting_Gamepad_Spacing, size.y / 2, rightSize, Text::Format("%.f%%", steerRight * 100.0f));
+			}
+		}
 	}
 
 	void RenderCateye(const vec2 &in size, CSceneVehicleVisState@ vis)

--- a/Source/Pads/Gamepad.as
+++ b/Source/Pads/Gamepad.as
@@ -139,9 +139,9 @@ class DashboardPadGamepad : IDashboardPad
 		// Up & Down texts
 		if (Setting_Gamepad_UpDownSymbols) {
 			nvg::BeginPath();
-			nvg::FontFace(g_font);
-			nvg::FontSize(midSize / 2);
-			nvg::FillColor(Setting_Gamepad_TextColor);
+			nvg::FontFace(m_font);
+			nvg::FontSize(Setting_Gamepad_FontSize * 1.5f);
+			nvg::FillColor(Setting_Gamepad_FontColor);
 			nvg::TextAlign(nvg::Align::Middle | nvg::Align::Center);
 			nvg::TextBox(midX, topSize / 2, midSize, Icons::AngleUp);
 			nvg::TextBox(midX, bottomY + bottomSize / 2, midSize, Icons::AngleDown);
@@ -150,8 +150,8 @@ class DashboardPadGamepad : IDashboardPad
 		// Steering percentage
 		if (Setting_Gamepad_SteerPercentage) {
 			nvg::FontFace(m_font);
-			nvg::FontSize(Setting_Gamepad_SteerPercentageSize);
-			nvg::FillColor(Setting_Gamepad_TextColor);
+			nvg::FontSize(Setting_Gamepad_FontSize);
+			nvg::FillColor(Setting_Gamepad_FontColor);
 
 			// Left
 			if (steerLeft > 0) {

--- a/Source/Pads/Gamepad.as
+++ b/Source/Pads/Gamepad.as
@@ -38,11 +38,6 @@ class DashboardPadGamepad : IDashboardPad
 		float bottomSize = size.y - bottomY;
 
 		nvg::StrokeWidth(Setting_Gamepad_BorderWidth);
-		if (Setting_Gamepad_UseBorderGradient) {
-			nvg::StrokePaint(Setting_Gamepad_BorderGradient.GetPaint(vec2(), size));
-		} else {
-			nvg::StrokeColor(Setting_Gamepad_BorderColor);
-		}
 		nvg::LineJoin(nvg::LineCapType::Round);
 
 		// Steering scales
@@ -77,6 +72,12 @@ class DashboardPadGamepad : IDashboardPad
 			nvg::Fill();
 			nvg::ResetScissor();
 		}
+		float fillAlpha = Math::Lerp(Setting_Gamepad_OffAlpha, 1.0f, steerLeft);
+		if (Setting_Gamepad_UseBorderGradient) {
+			nvg::StrokePaint(Setting_Gamepad_BorderGradient.GetPaint(vec2(), size, fillAlpha));
+		} else {
+			nvg::StrokeColor(Setting_Gamepad_BorderColor);
+		}
 		nvg::Stroke();
 
 		// Right
@@ -98,6 +99,12 @@ class DashboardPadGamepad : IDashboardPad
 			nvg::Fill();
 			nvg::ResetScissor();
 		}
+		fillAlpha = Math::Lerp(Setting_Gamepad_OffAlpha, 1.0f, steerRight);
+		if (Setting_Gamepad_UseBorderGradient) {
+			nvg::StrokePaint(Setting_Gamepad_BorderGradient.GetPaint(vec2(), size, fillAlpha));
+		} else {
+			nvg::StrokeColor(Setting_Gamepad_BorderColor);
+		}
 		nvg::Stroke();
 
 		// Up
@@ -116,6 +123,12 @@ class DashboardPadGamepad : IDashboardPad
 			nvg::Fill();
 			nvg::ResetScissor();
 		}
+		fillAlpha = pedalGas > 0.1f ? 1.0f : Setting_Gamepad_OffAlpha;
+		if (Setting_Gamepad_UseBorderGradient) {
+			nvg::StrokePaint(Setting_Gamepad_BorderGradient.GetPaint(vec2(), size, fillAlpha));
+		} else {
+			nvg::StrokeColor(Setting_Gamepad_BorderColor);
+		}
 		nvg::Stroke();
 
 		// Down
@@ -133,6 +146,12 @@ class DashboardPadGamepad : IDashboardPad
 			}
 			nvg::Fill();
 			nvg::ResetScissor();
+		}
+		fillAlpha = pedalBrake > 0.1f ? 1.0f : Setting_Gamepad_OffAlpha;
+		if (Setting_Gamepad_UseBorderGradient) {
+			nvg::StrokePaint(Setting_Gamepad_BorderGradient.GetPaint(vec2(), size, fillAlpha));
+		} else {
+			nvg::StrokeColor(Setting_Gamepad_BorderColor);
 		}
 		nvg::Stroke();
 

--- a/Source/Pads/Gamepad.as
+++ b/Source/Pads/Gamepad.as
@@ -169,34 +169,17 @@ class DashboardPadGamepad : IDashboardPad
 
 		// Steering percentage
 		if (Setting_Gamepad_SteerPercentage) {
-			nvg::FontFace(m_font);
-			nvg::FontSize(Setting_Gamepad_FontSize);
-
-			// Left
-			if (steerLeft > 0) {
-				nvg::BeginPath();
-				nvg::TextAlign(nvg::Align::Middle | nvg::Align::Right);
-				nvg::FillColor(WithAlpha(Setting_Gamepad_FontColor, fillAlphaLeft));
-				nvg::TextBox(
-					-Setting_Gamepad_SteerPercentageSpacing,
-					size.y / 2,
-					leftSize - Setting_Gamepad_Spacing,
-					Text::Format("%.f" + (Setting_Gamepad_SteerPercentageSymbol ? "%%" : ""), steerLeft * 100.0f)
-				);
-			}
-
-			// Right
-			if (steerRight > 0) {
-				nvg::BeginPath();
-				nvg::TextAlign(nvg::Align::Middle | nvg::Align::Left);
-				nvg::FillColor(WithAlpha(Setting_Gamepad_FontColor, fillAlphaRight));
-				nvg::TextBox(
-					Setting_Gamepad_SteerPercentageSpacing + rightX + Setting_Gamepad_Spacing,
-					size.y / 2,
-					rightSize,
-					Text::Format("%.f" + (Setting_Gamepad_SteerPercentageSymbol ? "%%" : ""), steerRight * 100.0f)
-				);
-			}
+			RenderSteerPercentage(
+				size.y / 2.0f,
+				Setting_Gamepad_Spacing,
+				steerLeft,
+				fillAlphaLeft,
+				leftSize,
+				steerRight,
+				fillAlphaRight,
+				rightX,
+				rightSize
+			);
 		}
 	}
 
@@ -272,34 +255,17 @@ class DashboardPadGamepad : IDashboardPad
 
 		// Steering percentage
 		if (Setting_Gamepad_SteerPercentage) {
-			nvg::FontFace(m_font);
-			nvg::FontSize(Setting_Gamepad_FontSize);
-
-			// Left
-			if (steerLeft > 0) {
-				nvg::BeginPath();
-				nvg::TextAlign(nvg::Align::Middle | nvg::Align::Right);
-				nvg::FillColor(WithAlpha(Setting_Gamepad_FontColor, Math::Lerp(Setting_Gamepad_OffAlpha, 1.0f, steerLeft)));
-				nvg::TextBox(
-					-Setting_Gamepad_SteerPercentageSpacing,
-					size.y / 2,
-					leftSize - Setting_Gamepad_Spacing,
-					Text::Format("%.f" + (Setting_Gamepad_SteerPercentageSymbol ? "%%" : ""), steerLeft * 100.0f)
-				);
-			}
-
-			// Right
-			if (steerRight > 0) {
-				nvg::BeginPath();
-				nvg::TextAlign(nvg::Align::Middle | nvg::Align::Left);
-				nvg::FillColor(WithAlpha(Setting_Gamepad_FontColor, Math::Lerp(Setting_Gamepad_OffAlpha, 1.0f, steerRight)));
-				nvg::TextBox(
-					Setting_Gamepad_SteerPercentageSpacing + rightX + Setting_Gamepad_Spacing,
-					size.y / 2,
-					rightSize,
-					Text::Format("%.f" + (Setting_Gamepad_SteerPercentageSymbol ? "%%" : ""), steerRight * 100.0f)
-				);
-			}
+			RenderSteerPercentage(
+				size.y / 2.0f,
+				Setting_Gamepad_Spacing,
+				steerLeft,
+				Math::Lerp(Setting_Gamepad_OffAlpha, 1.0f, steerLeft),
+				leftSize,
+				steerRight,
+				Math::Lerp(Setting_Gamepad_OffAlpha, 1.0f, steerRight),
+				rightX,
+				rightSize
+			);
 		}
 	}
 
@@ -435,6 +401,55 @@ class DashboardPadGamepad : IDashboardPad
 			nvg::StrokeColor(WithAlpha(Setting_Gamepad_BorderColor, fillAlphaDown));
 		}
 		StrokeInflectedTriangle(posMidBot, posBotInflection, posMidLeft, posMidRight);
+
+		if (Setting_Gamepad_SteerPercentage) {
+			float leftSize = size.x * (0.5f - Setting_Gamepad_MiddleScale / 2);
+			float midSize = size.x * Setting_Gamepad_MiddleScale;
+			float rightX = leftSize + midSize;
+			float rightSize = size.x - rightX;
+			RenderSteerPercentage(
+				size.y / 2.0f,
+				0.0f,
+				steerLeft,
+				fillAlphaLeft,
+				leftSize,
+				steerRight,
+				fillAlphaRight,
+				rightX,
+				rightSize
+			);
+		}
+	}
+
+	void RenderSteerPercentage(float y, float spacing, float steerLeft, float fillAlphaLeft, float leftSize, float steerRight, float fillAlphaRight, float rightX, float rightSize) {
+		nvg::FontFace(m_font);
+		nvg::FontSize(Setting_Gamepad_FontSize);
+
+		// Left
+		if (steerLeft > 0) {
+			nvg::BeginPath();
+			nvg::TextAlign(nvg::Align::Middle | nvg::Align::Right);
+			nvg::FillColor(WithAlpha(Setting_Gamepad_FontColor, fillAlphaLeft));
+			nvg::TextBox(
+				-Setting_Gamepad_SteerPercentageSpacing,
+				y,
+				leftSize - spacing,
+				Text::Format("%.f" + (Setting_Gamepad_SteerPercentageSymbol ? "%%" : ""), steerLeft * 100.0f)
+			);
+		}
+
+		// Right
+		if (steerRight > 0) {
+			nvg::BeginPath();
+			nvg::TextAlign(nvg::Align::Middle | nvg::Align::Left);
+			nvg::FillColor(WithAlpha(Setting_Gamepad_FontColor, fillAlphaRight));
+			nvg::TextBox(
+				Setting_Gamepad_SteerPercentageSpacing + rightX + spacing,
+				y,
+				rightSize,
+				Text::Format("%.f" + (Setting_Gamepad_SteerPercentageSymbol ? "%%" : ""), steerRight * 100.0f)
+			);
+		}
 	}
 
 	private void FillInflectedTriangle(const vec2 &in posApex, const vec2 &in posInflection, const vec2 &in posSide1, const vec2 &in posSide2)

--- a/Source/Pads/Gamepad.as
+++ b/Source/Pads/Gamepad.as
@@ -176,14 +176,24 @@ class DashboardPadGamepad : IDashboardPad
 			if (steerLeft > 0) {
 				nvg::BeginPath();
 				nvg::TextAlign(nvg::Align::Middle | nvg::Align::Right);
-				nvg::TextBox(0, size.y / 2, leftSize - Setting_Gamepad_Spacing, Text::Format("%.f%%", steerLeft * 100.0f));
+				nvg::TextBox(
+					-Setting_Gamepad_SteerPercentageSpacing,
+					size.y / 2,
+					leftSize - Setting_Gamepad_Spacing,
+					Text::Format("%.f" + (Setting_Gamepad_SteerPercentageSymbol ? "%%" : ""), steerLeft * 100.0f)
+				);
 			}
 
 			// Right
 			if (steerRight > 0) {
 				nvg::BeginPath();
 				nvg::TextAlign(nvg::Align::Middle | nvg::Align::Left);
-				nvg::TextBox(rightX + Setting_Gamepad_Spacing, size.y / 2, rightSize, Text::Format("%.f%%", steerRight * 100.0f));
+				nvg::TextBox(
+					Setting_Gamepad_SteerPercentageSpacing + rightX + Setting_Gamepad_Spacing,
+					size.y / 2,
+					rightSize,
+					Text::Format("%.f" + (Setting_Gamepad_SteerPercentageSymbol ? "%%" : ""), steerRight * 100.0f)
+				);
 			}
 		}
 	}
@@ -268,14 +278,24 @@ class DashboardPadGamepad : IDashboardPad
 			if (steerLeft > 0) {
 				nvg::BeginPath();
 				nvg::TextAlign(nvg::Align::Middle | nvg::Align::Right);
-				nvg::TextBox(0, size.y / 2, leftSize - Setting_Gamepad_Spacing, Text::Format("%.f%%", steerLeft * 100.0f));
+				nvg::TextBox(
+					-Setting_Gamepad_SteerPercentageSpacing,
+					size.y / 2,
+					leftSize - Setting_Gamepad_Spacing,
+					Text::Format("%.f" + (Setting_Gamepad_SteerPercentageSymbol ? "%%" : ""), steerLeft * 100.0f)
+				);
 			}
 
 			// Right
 			if (steerRight > 0) {
 				nvg::BeginPath();
 				nvg::TextAlign(nvg::Align::Middle | nvg::Align::Left);
-				nvg::TextBox(rightX + Setting_Gamepad_Spacing, size.y / 2, rightSize, Text::Format("%.f%%", steerRight * 100.0f));
+				nvg::TextBox(
+					Setting_Gamepad_SteerPercentageSpacing + rightX + Setting_Gamepad_Spacing,
+					size.y / 2,
+					rightSize,
+					Text::Format("%.f" + (Setting_Gamepad_SteerPercentageSymbol ? "%%" : ""), steerRight * 100.0f)
+				);
 			}
 		}
 	}

--- a/Source/Pads/Gamepad.as
+++ b/Source/Pads/Gamepad.as
@@ -306,7 +306,6 @@ class DashboardPadGamepad : IDashboardPad
 	void RenderCateye(const vec2 &in size, CSceneVehicleVisState@ vis)
 	{
 		nvg::StrokeWidth(Setting_Gamepad_BorderWidth);
-		nvg::StrokeColor(Setting_Gamepad_BorderColor);
 		nvg::LineJoin(nvg::LineCapType::Round);
 
 		// Steering scales
@@ -361,6 +360,12 @@ class DashboardPadGamepad : IDashboardPad
 			nvg::FillColor(Setting_Gamepad_FillColor);
 			FillInflectedTriangle(posLeftSteer, posLeftInflection, posTop, posBottom);
 		}
+		float fillAlphaLeft = Math::Lerp(Setting_Gamepad_OffAlpha, 1.0f, steerLeft);
+		if (Setting_Gamepad_UseBorderGradient) {
+			nvg::StrokePaint(Setting_Gamepad_BorderGradient.GetPaint(vec2(), size, fillAlphaLeft));
+		} else {
+			nvg::StrokeColor(WithAlpha(Setting_Gamepad_BorderColor, fillAlphaLeft));
+		}
 		StrokeInflectedTriangle(posLeft, posLeftInflection, posTop, posBottom);
 
 		// Right
@@ -375,16 +380,34 @@ class DashboardPadGamepad : IDashboardPad
 			nvg::FillColor(Setting_Gamepad_FillColor);
 			FillInflectedTriangle(posRightSteer, posRightInflection, posTop, posBottom);
 		}
+		float fillAlphaRight = Math::Lerp(Setting_Gamepad_OffAlpha, 1.0f, steerRight);
+		if (Setting_Gamepad_UseBorderGradient) {
+			nvg::StrokePaint(Setting_Gamepad_BorderGradient.GetPaint(vec2(), size, fillAlphaRight));
+		} else {
+			nvg::StrokeColor(WithAlpha(Setting_Gamepad_BorderColor, fillAlphaRight));
+		}
 		StrokeInflectedTriangle(posRight, posRightInflection, posTop, posBottom);
 
 		// Up
 		nvg::FillColor(pedalGas > 0.1f ? Setting_Gamepad_FillColor : Setting_Gamepad_EmptyFillColor);
 		FillInflectedTriangle(posMidTop, posTopInflection, posMidLeft, posMidRight);
+		float fillAlphaUp = pedalGas > 0.1f ? 1.0f : Setting_Gamepad_OffAlpha;
+		if (Setting_Gamepad_UseBorderGradient) {
+			nvg::StrokePaint(Setting_Gamepad_BorderGradient.GetPaint(vec2(), size, fillAlphaUp));
+		} else {
+			nvg::StrokeColor(WithAlpha(Setting_Gamepad_BorderColor, fillAlphaUp));
+		}
 		StrokeInflectedTriangle(posMidTop, posTopInflection, posMidLeft, posMidRight);
 
 		// Down
 		nvg::FillColor(pedalBrake > 0.1f ? Setting_Gamepad_FillColor : Setting_Gamepad_EmptyFillColor);
 		FillInflectedTriangle(posMidBot, posBotInflection, posMidLeft, posMidRight);
+		float fillAlphaDown = pedalBrake > 0.1f ? 1.0f : Setting_Gamepad_OffAlpha;
+		if (Setting_Gamepad_UseBorderGradient) {
+			nvg::StrokePaint(Setting_Gamepad_BorderGradient.GetPaint(vec2(), size, fillAlphaDown));
+		} else {
+			nvg::StrokeColor(WithAlpha(Setting_Gamepad_BorderColor, fillAlphaDown));
+		}
 		StrokeInflectedTriangle(posMidBot, posBotInflection, posMidLeft, posMidRight);
 	}
 

--- a/Source/Pads/Gamepad.as
+++ b/Source/Pads/Gamepad.as
@@ -274,12 +274,12 @@ class DashboardPadGamepad : IDashboardPad
 		if (Setting_Gamepad_SteerPercentage) {
 			nvg::FontFace(m_font);
 			nvg::FontSize(Setting_Gamepad_FontSize);
-			nvg::FillColor(Setting_Gamepad_FontColor);
 
 			// Left
 			if (steerLeft > 0) {
 				nvg::BeginPath();
 				nvg::TextAlign(nvg::Align::Middle | nvg::Align::Right);
+				nvg::FillColor(WithAlpha(Setting_Gamepad_FontColor, Math::Lerp(Setting_Gamepad_OffAlpha, 1.0f, steerLeft)));
 				nvg::TextBox(
 					-Setting_Gamepad_SteerPercentageSpacing,
 					size.y / 2,
@@ -292,6 +292,7 @@ class DashboardPadGamepad : IDashboardPad
 			if (steerRight > 0) {
 				nvg::BeginPath();
 				nvg::TextAlign(nvg::Align::Middle | nvg::Align::Left);
+				nvg::FillColor(WithAlpha(Setting_Gamepad_FontColor, Math::Lerp(Setting_Gamepad_OffAlpha, 1.0f, steerRight)));
 				nvg::TextBox(
 					Setting_Gamepad_SteerPercentageSpacing + rightX + Setting_Gamepad_Spacing,
 					size.y / 2,

--- a/Source/Pads/Keyboard.as
+++ b/Source/Pads/Keyboard.as
@@ -95,8 +95,13 @@ class DashboardPadKeyboard : IDashboardPad
 		nvg::FontFace(g_font);
 		nvg::FontSize(size.x / 2);
 		nvg::FillColor(Setting_Keyboard_TextColor);
-		if (Setting_Keyboard_ArrowSymbols) {
-			nvg::TextAlign(nvg::Align::Middle | nvg::Align::Center);
+		nvg::TextAlign(nvg::Align::Middle | nvg::Align::Center);
+		if (Setting_Keyboard_SteerPercentage && fillDir != 0) {
+			if (value > 0.0f) {
+				nvg::FontSize(Setting_Keyboard_SteerPercentageSize);
+				nvg::TextBox(pos.x, pos.y + size.y / 2, size.x, tostring(Math::Round(value * 100)) + "%");
+			}
+		} else if (Setting_Keyboard_ArrowSymbols) {
 			nvg::TextBox(pos.x, pos.y + size.y / 2, size.x, text);
 		}
 	}

--- a/Source/Pads/Keyboard.as
+++ b/Source/Pads/Keyboard.as
@@ -94,11 +94,7 @@ class DashboardPadKeyboard : IDashboardPad
 		nvg::BeginPath();
 		nvg::FontFace(g_font);
 		nvg::FontSize(size.x / 2);
-		if (Setting_Keyboard_UseBorderGradient) {
-			nvg::FillPaint(Setting_Keyboard_BorderGradient.GetPaint(vec2(), m_size, fillAlpha));
-		} else {
-			nvg::FillColor(borderColor);
-		}
+		nvg::FillColor(Setting_Keyboard_TextColor);
 		if (Setting_Keyboard_ArrowSymbols) {
 			nvg::TextAlign(nvg::Align::Middle | nvg::Align::Center);
 			nvg::TextBox(pos.x, pos.y + size.y / 2, size.x, text);

--- a/Source/Pads/Keyboard.as
+++ b/Source/Pads/Keyboard.as
@@ -99,7 +99,9 @@ class DashboardPadKeyboard : IDashboardPad
 		} else {
 			nvg::FillColor(borderColor);
 		}
-		nvg::TextAlign(nvg::Align::Middle | nvg::Align::Center);
-		nvg::TextBox(pos.x, pos.y + size.y / 2, size.x, text);
+		if (Setting_Keyboard_ArrowSymbols) {
+			nvg::TextAlign(nvg::Align::Middle | nvg::Align::Center);
+			nvg::TextBox(pos.x, pos.y + size.y / 2, size.x, text);
+		}
 	}
 }

--- a/Source/Pads/Keyboard.as
+++ b/Source/Pads/Keyboard.as
@@ -125,7 +125,7 @@ class DashboardPadKeyboard : IDashboardPad
 		if (Setting_Keyboard_SteerPercentage && fillDir != 0) {
 			if (value > 0.0f) {
 				nvg::FontSize(Setting_Keyboard_SteerPercentageSize);
-				nvg::TextBox(pos.x, pos.y + size.y / 2, size.x, tostring(Math::Round(value * 100)) + "%");
+				nvg::TextBox(pos.x, pos.y + size.y / 2, size.x, Text::Format("%.f%%", value * 100.0f));
 			}
 		} else if (Setting_Keyboard_ArrowSymbols) {
 			nvg::TextBox(pos.x, pos.y + size.y / 2, size.x, text);

--- a/Source/Pads/Keyboard.as
+++ b/Source/Pads/Keyboard.as
@@ -1,6 +1,32 @@
 class DashboardPadKeyboard : IDashboardPad
 {
+	nvg::Font m_font;
+	string m_fontPath;
+
 	vec2 m_size;
+
+	DashboardPadKeyboard()
+	{
+		LoadFont();
+	}
+
+	void LoadFont()
+	{
+		if (Setting_Keyboard_Font == m_fontPath) {
+			return;
+		}
+
+		auto font = nvg::LoadFont(Setting_Keyboard_Font);
+		if (font >= 0) {
+			m_fontPath = Setting_Keyboard_Font;
+			m_font = font;
+		}
+	}
+
+	void OnSettingsChanged() override
+	{
+		LoadFont();
+	}
 
 	void Render(const vec2 &in size, CSceneVehicleVisState@ vis) override
 	{
@@ -92,7 +118,7 @@ class DashboardPadKeyboard : IDashboardPad
 		nvg::Stroke();
 
 		nvg::BeginPath();
-		nvg::FontFace(g_font);
+		nvg::FontFace(m_font);
 		nvg::FontSize(size.x / 2);
 		nvg::FillColor(Setting_Keyboard_TextColor);
 		nvg::TextAlign(nvg::Align::Middle | nvg::Align::Center);

--- a/Source/Pads/Keyboard.as
+++ b/Source/Pads/Keyboard.as
@@ -117,10 +117,13 @@ class DashboardPadKeyboard : IDashboardPad
 		}
 		nvg::Stroke();
 
+		vec4 textColor = Setting_Keyboard_TextColor;
+		textColor.w *= fillAlpha;
+
 		nvg::BeginPath();
 		nvg::FontFace(m_font);
 		nvg::FontSize(size.x / 2);
-		nvg::FillColor(Setting_Keyboard_TextColor);
+		nvg::FillColor(textColor);
 		nvg::TextAlign(nvg::Align::Middle | nvg::Align::Center);
 		if (Setting_Keyboard_SteerPercentage && fillDir != 0) {
 			if (value > 0.0f) {

--- a/Source/Pads/Keyboard.as
+++ b/Source/Pads/Keyboard.as
@@ -127,7 +127,12 @@ class DashboardPadKeyboard : IDashboardPad
 		if (Setting_Keyboard_SteerPercentage && fillDir != 0) {
 			if (value > 0.0f) {
 				nvg::FontSize(Setting_Keyboard_FontSize);
-				nvg::TextBox(pos.x, pos.y + size.y / 2, size.x, Text::Format("%.f%%", value * 100.0f));
+				nvg::TextBox(
+					pos.x,
+					pos.y + size.y / 2,
+					size.x,
+					Text::Format("%.f" + (Setting_Keyboard_SteerPercentageSymbol ? "%%" : ""), value * 100.0f)
+				);
 			}
 		} else if (Setting_Keyboard_ArrowSymbols) {
 			nvg::FontSize(Setting_Keyboard_FontSize * 1.5f);

--- a/Source/Pads/Keyboard.as
+++ b/Source/Pads/Keyboard.as
@@ -117,20 +117,20 @@ class DashboardPadKeyboard : IDashboardPad
 		}
 		nvg::Stroke();
 
-		vec4 textColor = Setting_Keyboard_TextColor;
+		vec4 textColor = Setting_Keyboard_FontColor;
 		textColor.w *= fillAlpha;
 
 		nvg::BeginPath();
 		nvg::FontFace(m_font);
-		nvg::FontSize(size.x / 2);
 		nvg::FillColor(textColor);
 		nvg::TextAlign(nvg::Align::Middle | nvg::Align::Center);
 		if (Setting_Keyboard_SteerPercentage && fillDir != 0) {
 			if (value > 0.0f) {
-				nvg::FontSize(Setting_Keyboard_SteerPercentageSize);
+				nvg::FontSize(Setting_Keyboard_FontSize);
 				nvg::TextBox(pos.x, pos.y + size.y / 2, size.x, Text::Format("%.f%%", value * 100.0f));
 			}
 		} else if (Setting_Keyboard_ArrowSymbols) {
+			nvg::FontSize(Setting_Keyboard_FontSize * 1.5f);
 			nvg::TextBox(pos.x, pos.y + size.y / 2, size.x, text);
 		}
 	}

--- a/Source/Settings.as
+++ b/Source/Settings.as
@@ -135,6 +135,9 @@ bool Setting_Gamepad_SteerPercentage = false;
 	if="Setting_Gamepad_Style Uniform"]
 int Setting_Gamepad_SteerPercentageSize = 16;
 
+[Setting category="Gamepad" name="Font" if="Setting_Gamepad_Style Uniform"]
+string Setting_Gamepad_Font = "DroidSans.ttf";
+
 [Setting category="Gamepad" name="Text and symbol color" color if="Setting_Gamepad_Style Uniform"]
 vec4 Setting_Gamepad_TextColor = vec4(1, 1, 1, 1);
 
@@ -194,6 +197,9 @@ bool Setting_Keyboard_SteerPercentage = false;
 	name="Steer percentage size"
 	drag min=2 max=40]
 int Setting_Keyboard_SteerPercentageSize = 16;
+
+[Setting category="Keyboard" name="Font"]
+string Setting_Keyboard_Font = "DroidSans.ttf";
 
 [Setting category="Keyboard" name="Text and symbol color" color]
 vec4 Setting_Keyboard_TextColor = vec4(1, 1, 1, 1);

--- a/Source/Settings.as
+++ b/Source/Settings.as
@@ -125,20 +125,20 @@ bool Setting_Gamepad_UpDownSymbols = true;
 [Setting category="Gamepad" name="Cateye use simple steer" if="Setting_Gamepad_Style Cateye"]
 bool Setting_Gamepad_CateyeUseSimpleSteer = false;
 
-[Setting category="Gamepad" name="Display steer percentage" if="Setting_Gamepad_Style Uniform"]
+[Setting category="Gamepad" name="Display steer percentage" if="!Setting_Gamepad_Style Cateye"]
 bool Setting_Gamepad_SteerPercentage = false;
 
-[Setting category="Gamepad" name="Font" if="Setting_Gamepad_Style Uniform"]
+[Setting category="Gamepad" name="Font" if="!Setting_Gamepad_Style Cateye"]
 string Setting_Gamepad_Font = "DroidSans.ttf";
 
 [Setting
 	category="Gamepad"
 	name="Font size"
 	min=2 max=40
-	if="Setting_Gamepad_Style Uniform"]
+	if="!Setting_Gamepad_Style Cateye"]
 int Setting_Gamepad_FontSize = 16;
 
-[Setting category="Gamepad" name="Font color" color if="Setting_Gamepad_Style Uniform"]
+[Setting category="Gamepad" name="Font color" color if="!Setting_Gamepad_Style Cateye"]
 vec4 Setting_Gamepad_FontColor = vec4(1, 1, 1, 1);
 
 

--- a/Source/Settings.as
+++ b/Source/Settings.as
@@ -116,7 +116,7 @@ vec4 Setting_Gamepad_ClassicUpColor = vec4(0.2f, 1, 0.6f, 1);
 [Setting category="Gamepad" name="Classic down color" color if="Setting_Gamepad_Style Classic"]
 vec4 Setting_Gamepad_ClassicDownColor = vec4(1, 0.6f, 0.2f, 1);
 
-[Setting category="Gamepad" name="Classic off alpha" drag min=0 max=1 if="Setting_Gamepad_Style Classic"]
+[Setting category="Gamepad" name="Inactive alpha" min=0 max=1]
 float Setting_Gamepad_OffAlpha = 0.33f;
 
 [Setting category="Gamepad" name="Display up/down arrow symbols" if="Setting_Gamepad_Style Uniform"]

--- a/Source/Settings.as
+++ b/Source/Settings.as
@@ -128,6 +128,12 @@ bool Setting_Gamepad_CateyeUseSimpleSteer = false;
 [Setting category="Gamepad" name="Display steer percentage" if="!Setting_Gamepad_Style Cateye"]
 bool Setting_Gamepad_SteerPercentage = false;
 
+[Setting category="Gamepad" name="Display steer percentage symbol" if="!Setting_Gamepad_Style Cateye"]
+bool Setting_Gamepad_SteerPercentageSymbol = true;
+
+[Setting category="Gamepad" name="Steer percentage spacing" min=-100 max=100 if="!Setting_Gamepad_Style Cateye"]
+float Setting_Gamepad_SteerPercentageSpacing = 0.0f;
+
 [Setting category="Gamepad" name="Font" if="!Setting_Gamepad_Style Cateye"]
 string Setting_Gamepad_Font = "DroidSans.ttf";
 
@@ -191,6 +197,9 @@ bool Setting_Keyboard_ArrowSymbols = true;
 
 [Setting category="Keyboard" name="Display steer percentage" description="Overrides left/right arrows of setting above"]
 bool Setting_Keyboard_SteerPercentage = false;
+
+[Setting category="Keyboard" name="Display steer percentage symbol"]
+bool Setting_Keyboard_SteerPercentageSymbol = true;
 
 [Setting category="Keyboard" name="Font"]
 string Setting_Keyboard_Font = "DroidSans.ttf";

--- a/Source/Settings.as
+++ b/Source/Settings.as
@@ -80,7 +80,7 @@ GamepadStyle Setting_Gamepad_Style = GamepadStyle::Uniform;
 [Setting category="Gamepad" name="Empty fill color" color if="!Setting_Gamepad_Style Classic"]
 vec4 Setting_Gamepad_EmptyFillColor = vec4(0, 0, 0, 0.7f);
 
-[Setting category="Gamepad" name="Fill gradient"]
+[Setting category="Gamepad" name="Fill gradient" description="Only applies to Uniform and Cateye styles"]
 bool Setting_Gamepad_UseFillGradient = false;
 
 [Setting category="Gamepad" name="Fill color" color if="!Setting_Gamepad_UseFillGradient"]
@@ -89,7 +89,7 @@ vec4 Setting_Gamepad_FillColor = vec4(1, 0.2f, 0.6f, 1);
 [Setting category="Gamepad" name="Fill gradient" if="Setting_Gamepad_UseFillGradient"]
 SettingsGradient Setting_Gamepad_FillGradient = SettingsGradient(vec4(1, 0.2f, 0.6f, 1), vec4(1, 0.6f, 0.9f, 1));
 
-[Setting category="Gamepad" name="Border gradient"]
+[Setting category="Gamepad" name="Border gradient" description="Only applies to Uniform and Cateye styles"]
 bool Setting_Gamepad_UseBorderGradient = false;
 
 [Setting category="Gamepad" name="Border color" color if="!Setting_Gamepad_UseBorderGradient"]

--- a/Source/Settings.as
+++ b/Source/Settings.as
@@ -128,18 +128,18 @@ bool Setting_Gamepad_CateyeUseSimpleSteer = false;
 [Setting category="Gamepad" name="Display steer percentage" if="Setting_Gamepad_Style Uniform"]
 bool Setting_Gamepad_SteerPercentage = false;
 
-[Setting
-	category="Gamepad"
-	name="Steer percentage size"
-	drag min=2 max=40
-	if="Setting_Gamepad_Style Uniform"]
-int Setting_Gamepad_SteerPercentageSize = 16;
-
 [Setting category="Gamepad" name="Font" if="Setting_Gamepad_Style Uniform"]
 string Setting_Gamepad_Font = "DroidSans.ttf";
 
-[Setting category="Gamepad" name="Text and symbol color" color if="Setting_Gamepad_Style Uniform"]
-vec4 Setting_Gamepad_TextColor = vec4(1, 1, 1, 1);
+[Setting
+	category="Gamepad"
+	name="Font size"
+	min=2 max=40
+	if="Setting_Gamepad_Style Uniform"]
+int Setting_Gamepad_FontSize = 16;
+
+[Setting category="Gamepad" name="Font color" color if="Setting_Gamepad_Style Uniform"]
+vec4 Setting_Gamepad_FontColor = vec4(1, 1, 1, 1);
 
 
 
@@ -192,17 +192,17 @@ bool Setting_Keyboard_ArrowSymbols = true;
 [Setting category="Keyboard" name="Display steer percentage" description="Overrides left/right arrows of setting above"]
 bool Setting_Keyboard_SteerPercentage = false;
 
-[Setting
-	category="Keyboard"
-	name="Steer percentage size"
-	drag min=2 max=40]
-int Setting_Keyboard_SteerPercentageSize = 16;
-
 [Setting category="Keyboard" name="Font"]
 string Setting_Keyboard_Font = "DroidSans.ttf";
 
-[Setting category="Keyboard" name="Text and symbol color" color]
-vec4 Setting_Keyboard_TextColor = vec4(1, 1, 1, 1);
+[Setting
+	category="Keyboard"
+	name="Font size"
+	min=2 max=40]
+int Setting_Keyboard_FontSize = 16;
+
+[Setting category="Keyboard" name="Font color" color]
+vec4 Setting_Keyboard_FontColor = vec4(1, 1, 1, 1);
 
 
 

--- a/Source/Settings.as
+++ b/Source/Settings.as
@@ -125,26 +125,25 @@ bool Setting_Gamepad_UpDownSymbols = true;
 [Setting category="Gamepad" name="Cateye use simple steer" description="Does not yet show fill gradient correctly" if="Setting_Gamepad_Style Cateye"]
 bool Setting_Gamepad_CateyeUseSimpleSteer = false;
 
-[Setting category="Gamepad" name="Display steer percentage" if="!Setting_Gamepad_Style Cateye"]
+[Setting category="Gamepad" name="Display steer percentage"]
 bool Setting_Gamepad_SteerPercentage = false;
 
-[Setting category="Gamepad" name="Display steer percentage symbol" if="!Setting_Gamepad_Style Cateye"]
+[Setting category="Gamepad" name="Display steer percentage symbol"]
 bool Setting_Gamepad_SteerPercentageSymbol = true;
 
-[Setting category="Gamepad" name="Steer percentage spacing" min=-100 max=100 if="!Setting_Gamepad_Style Cateye"]
+[Setting category="Gamepad" name="Steer percentage spacing" min=-100 max=100]
 float Setting_Gamepad_SteerPercentageSpacing = 0.0f;
 
-[Setting category="Gamepad" name="Font" if="!Setting_Gamepad_Style Cateye"]
+[Setting category="Gamepad" name="Font"]
 string Setting_Gamepad_Font = "DroidSans.ttf";
 
 [Setting
 	category="Gamepad"
 	name="Font size"
-	min=2 max=40
-	if="!Setting_Gamepad_Style Cateye"]
+	min=2 max=40]
 int Setting_Gamepad_FontSize = 16;
 
-[Setting category="Gamepad" name="Font color" color if="!Setting_Gamepad_Style Cateye"]
+[Setting category="Gamepad" name="Font color" color]
 vec4 Setting_Gamepad_FontColor = vec4(1, 1, 1, 1);
 
 

--- a/Source/Settings.as
+++ b/Source/Settings.as
@@ -183,6 +183,9 @@ float Setting_Keyboard_Spacing = 10.0f;
 [Setting category="Keyboard" name="Inactive alpha" drag min=0 max=1]
 float Setting_Keyboard_InactiveAlpha = 1.0f;
 
+[Setting category="Keyboard" name="Display arrow symbols"]
+bool Setting_Keyboard_ArrowSymbols = true;
+
 
 
 [Setting category="Gearbox" name="Show text"]

--- a/Source/Settings.as
+++ b/Source/Settings.as
@@ -186,6 +186,9 @@ float Setting_Keyboard_InactiveAlpha = 1.0f;
 [Setting category="Keyboard" name="Display arrow symbols"]
 bool Setting_Keyboard_ArrowSymbols = true;
 
+[Setting category="Keyboard" name="Text and symbol color" color]
+vec4 Setting_Keyboard_TextColor = vec4(1, 1, 1, 1);
+
 
 
 [Setting category="Gearbox" name="Show text"]

--- a/Source/Settings.as
+++ b/Source/Settings.as
@@ -186,6 +186,15 @@ float Setting_Keyboard_InactiveAlpha = 1.0f;
 [Setting category="Keyboard" name="Display arrow symbols"]
 bool Setting_Keyboard_ArrowSymbols = true;
 
+[Setting category="Keyboard" name="Display steer percentage" description="Overrides left/right arrows of setting above"]
+bool Setting_Keyboard_SteerPercentage = false;
+
+[Setting
+	category="Keyboard"
+	name="Steer percentage size"
+	drag min=2 max=40]
+int Setting_Keyboard_SteerPercentageSize = 16;
+
 [Setting category="Keyboard" name="Text and symbol color" color]
 vec4 Setting_Keyboard_TextColor = vec4(1, 1, 1, 1);
 

--- a/Source/Settings.as
+++ b/Source/Settings.as
@@ -122,7 +122,7 @@ float Setting_Gamepad_OffAlpha = 0.33f;
 [Setting category="Gamepad" name="Display up/down arrow symbols" if="Setting_Gamepad_Style Uniform"]
 bool Setting_Gamepad_UpDownSymbols = true;
 
-[Setting category="Gamepad" name="Cateye use simple steer" if="Setting_Gamepad_Style Cateye"]
+[Setting category="Gamepad" name="Cateye use simple steer" description="Does not yet show fill gradient correctly" if="Setting_Gamepad_Style Cateye"]
 bool Setting_Gamepad_CateyeUseSimpleSteer = false;
 
 [Setting category="Gamepad" name="Display steer percentage" if="!Setting_Gamepad_Style Cateye"]

--- a/Source/Things/Acceleration.as
+++ b/Source/Things/Acceleration.as
@@ -47,7 +47,7 @@ class DashboardAcceleration : DashboardThing
 		}
 
 		auto font = nvg::LoadFont(Setting_Acceleration_Font);
-		if (font > 0) {
+		if (font >= 0) {
 			m_fontPath = Setting_Acceleration_Font;
 			m_font = font;
 		}

--- a/Source/Things/Clock.as
+++ b/Source/Things/Clock.as
@@ -42,7 +42,7 @@ class DashboardClock : DashboardThing
 		}
 
 		auto font = nvg::LoadFont(Setting_Clock_Font);
-		if (font > 0) {
+		if (font >= 0) {
 			m_fontPath = Setting_Clock_Font;
 			m_font = font;
 		}

--- a/Source/Things/Gearbox.as
+++ b/Source/Things/Gearbox.as
@@ -45,7 +45,7 @@ class DashboardGearbox : DashboardThing
 		}
 
 		auto font = nvg::LoadFont(Setting_Gearbox_Font);
-		if (font > 0) {
+		if (font >= 0) {
 			m_fontPath = Setting_Gearbox_Font;
 			m_font = font;
 		}

--- a/Source/Things/PadHost.as
+++ b/Source/Things/PadHost.as
@@ -1,5 +1,6 @@
 interface IDashboardPad
 {
+	void OnSettingsChanged();
 	void Render(const vec2 &in size, CSceneVehicleVisState@ vis);
 }
 
@@ -101,6 +102,12 @@ class DashboardPadHost : DashboardThing
 			case CInputScriptPad::EPadType::PlayStation:
 				@m_pad = DashboardPadGamepad();
 				break;
+		}
+	}
+
+	void OnSettingsChanged() override {
+		if (m_pad !is null) {
+			m_pad.OnSettingsChanged();
 		}
 	}
 }

--- a/Source/Things/Speed.as
+++ b/Source/Things/Speed.as
@@ -42,7 +42,7 @@ class DashboardSpeed : DashboardThing
 		}
 
 		auto font = nvg::LoadFont(Setting_Speed_Font);
-		if (font > 0) {
+		if (font >= 0) {
 			m_fontPath = Setting_Speed_Font;
 			m_font = font;
 		}

--- a/Source/Things/Wheels.as
+++ b/Source/Things/Wheels.as
@@ -64,7 +64,7 @@ class DashboardWheels : DashboardThing
 		}
 
 		auto font = nvg::LoadFont(Setting_Wheels_DetailsFont);
-		if (font > 0) {
+		if (font >= 0) {
 			m_fontPath = Setting_Wheels_DetailsFont;
 			m_font = font;
 		}


### PR DESCRIPTION
gamepad:
  - added steer percentage to Classic and Cateye
  - added inactive alpha to Uniform and Cateye
  - added border gradient to Cateye
  - added fill gradient to Cateye (but not for simple steering)
  - added descriptions on gradient settings

keyboard:
  - added setting for arrow symbols
  - added setting for steer percentage
  - untethered font color from border gradient color

both:
  - added more settings for font
  - added more settings for steer percentage

other:
  - fixed loading default font