### PR TITLE
Implement gear light tachometer

### DIFF
--- a/Source/Settings.as
+++ b/Source/Settings.as
@@ -271,10 +271,10 @@ bool Setting_Gearbox_Lights_UseGearColors = false;
 [Setting category="Gearbox" name="Gear light color" color if="Setting_Gearbox_TachometerStyle Lights"]
 vec4 Setting_Gearbox_Lights_Color = vec4(0.568f, 1, 0.961f, 1);
 
-[Setting category="Gearbox" name="Gear light reverse color" color if="Setting_Gearbox_TachometerStyle Lights"]
+[Setting category="Gearbox" name="Gear light color for gear 0 (reverse)" color if="Setting_Gearbox_TachometerStyle Lights"]
 vec4 Setting_Gearbox_Lights_Color_Reverse = vec4(1, 0.216f, 0.216f, 1);
 
-[Setting category="Gearbox" name="Gear light background color" color if="Setting_Gearbox_TachometerStyle Lights"]
+[Setting category="Gearbox" name="Background color for unlit gear lights" color if="Setting_Gearbox_TachometerStyle Lights"]
 vec4 Setting_Gearbox_Lights_Color_Background = vec4(0.1f, 0.1f, 0.1f, 1);
 
 #if MP4 || TURBO

--- a/Source/Settings.as
+++ b/Source/Settings.as
@@ -199,6 +199,7 @@ enum GearboxTachometerStyle
 	Bar,
 	Dots,
 	Blocks,
+	Lights,
 }
 
 [Setting category="Gearbox" name="Tachometer style" if="Setting_Gearbox_ShowTachometer"]
@@ -263,6 +264,18 @@ vec4 Setting_Gearbox_Gear4Color = vec4(1, 1, 1, 1);
 
 [Setting category="Gearbox" name="Gear 5 color" color if="Setting_Gearbox_UseGearColors"]
 vec4 Setting_Gearbox_Gear5Color = vec4(1, 1, 1, 1);
+
+[Setting category="Gearbox" name="Use gear colors for lights" if="Setting_Gearbox_TachometerStyle Lights"]
+bool Setting_Gearbox_Lights_UseGearColors = false;
+
+[Setting category="Gearbox" name="Gear light color" color if="Setting_Gearbox_TachometerStyle Lights"]
+vec4 Setting_Gearbox_Lights_Color = vec4(0.568f, 1, 0.961f, 1);
+
+[Setting category="Gearbox" name="Gear light reverse color" color if="Setting_Gearbox_TachometerStyle Lights"]
+vec4 Setting_Gearbox_Lights_Color_Reverse = vec4(1, 0.216f, 0.216f, 1);
+
+[Setting category="Gearbox" name="Gear light background color" color if="Setting_Gearbox_TachometerStyle Lights"]
+vec4 Setting_Gearbox_Lights_Color_Background = vec4(0.1f, 0.1f, 0.1f, 1);
 
 #if MP4 || TURBO
 	[Setting category="Gearbox" name="Gear 6 color" color if="Setting_Gearbox_UseGearColors"]

--- a/Source/Settings.as
+++ b/Source/Settings.as
@@ -265,6 +265,9 @@ vec4 Setting_Gearbox_Gear4Color = vec4(1, 1, 1, 1);
 [Setting category="Gearbox" name="Gear 5 color" color if="Setting_Gearbox_UseGearColors"]
 vec4 Setting_Gearbox_Gear5Color = vec4(1, 1, 1, 1);
 
+[Setting category="Gearbox" name="Show low/high RPM colors on gear lights" if="Setting_Gearbox_TachometerStyle Lights"]
+bool Setting_Gearbox_Lights_ShowLowHighRPM = true;
+
 [Setting category="Gearbox" name="Gear light color (if not using gear colors)" color if="Setting_Gearbox_TachometerStyle Lights"]
 vec4 Setting_Gearbox_Lights_Color = vec4(0.568f, 1, 0.961f, 1);
 

--- a/Source/Settings.as
+++ b/Source/Settings.as
@@ -265,13 +265,10 @@ vec4 Setting_Gearbox_Gear4Color = vec4(1, 1, 1, 1);
 [Setting category="Gearbox" name="Gear 5 color" color if="Setting_Gearbox_UseGearColors"]
 vec4 Setting_Gearbox_Gear5Color = vec4(1, 1, 1, 1);
 
-[Setting category="Gearbox" name="Use gear colors for lights" if="Setting_Gearbox_TachometerStyle Lights"]
-bool Setting_Gearbox_Lights_UseGearColors = false;
-
-[Setting category="Gearbox" name="Gear light color" color if="Setting_Gearbox_TachometerStyle Lights"]
+[Setting category="Gearbox" name="Gear light color (if not using gear colors)" color if="Setting_Gearbox_TachometerStyle Lights"]
 vec4 Setting_Gearbox_Lights_Color = vec4(0.568f, 1, 0.961f, 1);
 
-[Setting category="Gearbox" name="Gear light color for gear 0 (reverse)" color if="Setting_Gearbox_TachometerStyle Lights"]
+[Setting category="Gearbox" name="Gear light color for gear 0 (backwards, if not using gear colors)" color if="Setting_Gearbox_TachometerStyle Lights"]
 vec4 Setting_Gearbox_Lights_Color_Reverse = vec4(1, 0.216f, 0.216f, 1);
 
 [Setting category="Gearbox" name="Background color for unlit gear lights" color if="Setting_Gearbox_TachometerStyle Lights"]

--- a/Source/Things/Gearbox.as
+++ b/Source/Things/Gearbox.as
@@ -109,7 +109,7 @@ class DashboardGearbox : DashboardThing
 		}
 	}
 
-	void RenderTachometer(const vec2 &in pos, const vec2 &in size, float rpm)
+	void RenderTachometer(const vec2 &in pos, const vec2 &in size, float rpm, uint gear)
 	{
 		float rpmWidth = rpm / m_maxRpm * size.x;
 		float downWidth = Setting_Gearbox_Downshift / m_maxRpm * size.x;
@@ -208,6 +208,50 @@ class DashboardGearbox : DashboardThing
 				}
 				break;
 			}
+
+			case GearboxTachometerStyle::Lights: {
+				uint lights = gear;
+				vec4 color = Setting_Gearbox_Lights_Color;
+
+				if (gear == 0) {
+					lights = 5;
+					color = Setting_Gearbox_Lights_Color_Reverse;
+				}
+
+				if (Setting_Gearbox_Lights_UseGearColors) {
+					switch (gear) {
+						case 0: color = Setting_Gearbox_Gear0Color; break;
+						case 1: color = Setting_Gearbox_Gear1Color; break;
+						case 2: color = Setting_Gearbox_Gear2Color; break;
+						case 3: color = Setting_Gearbox_Gear3Color; break;
+						case 4: color = Setting_Gearbox_Gear4Color; break;
+						case 5: color = Setting_Gearbox_Gear5Color; break;
+					}
+				}
+
+				float lightPadding = 8.0f;
+				float spaceForPadding = lightPadding * 6.0;
+				float lightSize = (size.x - spaceForPadding) / 5.0;
+
+				for (uint i = 0; i < 5; i++) {
+					nvg::BeginPath();
+					nvg::RoundedRect(
+						pos.x + (i + 1) * lightPadding + i * lightSize,
+						pos.y + lightPadding,
+						lightSize,
+						size.y - 2 * lightPadding,
+						4
+					);
+					if (i < lights) {
+						nvg::FillColor(color);
+					} else {
+						nvg::FillColor(Setting_Gearbox_Lights_Color_Background);
+					}
+					nvg::Fill();
+				}
+
+				break;
+			}
 		}
 
 		// Border
@@ -237,7 +281,7 @@ class DashboardGearbox : DashboardThing
 		}
 
 		if (Setting_Gearbox_ShowTachometer) {
-			RenderTachometer(offset, size, rpm);
+			RenderTachometer(offset, size, rpm, gear);
 		}
 	}
 }

--- a/Source/Things/Gearbox.as
+++ b/Source/Things/Gearbox.as
@@ -218,7 +218,7 @@ class DashboardGearbox : DashboardThing
 					color = Setting_Gearbox_Lights_Color_Reverse;
 				}
 
-				if (Setting_Gearbox_Lights_UseGearColors) {
+				if (Setting_Gearbox_UseGearColors && Setting_Gearbox_Lights_UseGearColors) {
 					switch (gear) {
 						case 0: color = Setting_Gearbox_Gear0Color; break;
 						case 1: color = Setting_Gearbox_Gear1Color; break;

--- a/Source/Things/Gearbox.as
+++ b/Source/Things/Gearbox.as
@@ -56,6 +56,26 @@ class DashboardGearbox : DashboardThing
 		LoadFont();
 	}
 
+	vec4 GearColor(uint gear)
+	{
+		switch (gear) {
+			case 0: return Setting_Gearbox_Gear0Color;
+			case 1: return Setting_Gearbox_Gear1Color;
+			case 2: return Setting_Gearbox_Gear2Color;
+			case 3: return Setting_Gearbox_Gear3Color;
+			case 4: return Setting_Gearbox_Gear4Color;
+			case 5: return Setting_Gearbox_Gear5Color;
+#if MP4 || TURBO
+			case 6: return Setting_Gearbox_Gear6Color;
+			case 7: return Setting_Gearbox_Gear7Color;
+#endif
+#if TURBO
+			case 8: return Setting_Gearbox_Gear8Color;
+			case 9: return Setting_Gearbox_Gear9Color;
+#endif
+		}
+	}
+
 	void RenderNumbers(const vec2 &in pos, const vec2 &in size, uint gear, float rpm)
 	{
 		nvg::BeginPath();
@@ -70,23 +90,7 @@ class DashboardGearbox : DashboardThing
 
 		vec4 textColor = Setting_Gearbox_TextColor;
 		if (Setting_Gearbox_UseGearColors) {
-
-			switch (gear) {
-				case 0: textColor = Setting_Gearbox_Gear0Color; break;
-				case 1: textColor = Setting_Gearbox_Gear1Color; break;
-				case 2: textColor = Setting_Gearbox_Gear2Color; break;
-				case 3: textColor = Setting_Gearbox_Gear3Color; break;
-				case 4: textColor = Setting_Gearbox_Gear4Color; break;
-				case 5: textColor = Setting_Gearbox_Gear5Color; break;
-#if MP4 || TURBO
-				case 6: textColor = Setting_Gearbox_Gear6Color; break;
-				case 7: textColor = Setting_Gearbox_Gear7Color; break;
-#endif
-#if TURBO
-				case 8: textColor = Setting_Gearbox_Gear8Color; break;
-				case 9: textColor = Setting_Gearbox_Gear9Color; break;
-#endif
-			}
+			textColor = GearColor(gear);
 		}
 		nvg::FontFace(m_font);
 		nvg::FillColor(textColor);
@@ -219,14 +223,7 @@ class DashboardGearbox : DashboardThing
 				}
 
 				if (Setting_Gearbox_UseGearColors && Setting_Gearbox_Lights_UseGearColors) {
-					switch (gear) {
-						case 0: color = Setting_Gearbox_Gear0Color; break;
-						case 1: color = Setting_Gearbox_Gear1Color; break;
-						case 2: color = Setting_Gearbox_Gear2Color; break;
-						case 3: color = Setting_Gearbox_Gear3Color; break;
-						case 4: color = Setting_Gearbox_Gear4Color; break;
-						case 5: color = Setting_Gearbox_Gear5Color; break;
-					}
+					color = GearColor(gear);
 				}
 
 				float lightPadding = 8.0f;
@@ -240,7 +237,7 @@ class DashboardGearbox : DashboardThing
 						pos.y + lightPadding,
 						lightSize,
 						size.y - 2 * lightPadding,
-						4
+						Setting_Gearbox_BorderRadius
 					);
 					if (i < lights) {
 						nvg::FillColor(color);

--- a/Source/Things/Gearbox.as
+++ b/Source/Things/Gearbox.as
@@ -1,3 +1,11 @@
+#if MP4
+const uint MAX_GEAR = 7;
+#elif TURBO
+const uint MAX_GEAR = 9;
+#else
+const uint MAX_GEAR = 5;
+#endif
+
 class DashboardGearbox : DashboardThing
 {
 	float m_minRpm = 200.0f; // Minimal RPM to avoid flickering at engine idle
@@ -73,6 +81,7 @@ class DashboardGearbox : DashboardThing
 			case 8: return Setting_Gearbox_Gear8Color;
 			case 9: return Setting_Gearbox_Gear9Color;
 #endif
+			default: return Setting_Gearbox_Gear0Color;
 		}
 	}
 
@@ -218,7 +227,7 @@ class DashboardGearbox : DashboardThing
 				vec4 color = Setting_Gearbox_Lights_Color;
 
 				if (gear == 0) {
-					lights = 5;
+					lights = MAX_GEAR;
 					color = Setting_Gearbox_Lights_Color_Reverse;
 				}
 
@@ -227,10 +236,10 @@ class DashboardGearbox : DashboardThing
 				}
 
 				float lightPadding = 8.0f;
-				float spaceForPadding = lightPadding * 6.0;
-				float lightSize = (size.x - spaceForPadding) / 5.0;
+				float spaceForPadding = lightPadding * float(MAX_GEAR + 1);
+				float lightSize = (size.x - spaceForPadding) / float(MAX_GEAR);
 
-				for (uint i = 0; i < 5; i++) {
+				for (uint i = 0; i < MAX_GEAR; i++) {
 					nvg::BeginPath();
 					nvg::RoundedRect(
 						pos.x + (i + 1) * lightPadding + i * lightSize,

--- a/Source/Things/Gearbox.as
+++ b/Source/Things/Gearbox.as
@@ -231,7 +231,7 @@ class DashboardGearbox : DashboardThing
 					color = Setting_Gearbox_Lights_Color_Reverse;
 				}
 
-				if (Setting_Gearbox_UseGearColors && Setting_Gearbox_Lights_UseGearColors) {
+				if (Setting_Gearbox_UseGearColors) {
 					color = GearColor(gear);
 				}
 

--- a/Source/Things/Gearbox.as
+++ b/Source/Things/Gearbox.as
@@ -235,10 +235,12 @@ class DashboardGearbox : DashboardThing
 					color = GearColor(gear);
 				}
 
-				if (rpm <= Setting_Gearbox_Downshift && gear >= 2) {
-					color = Setting_Gearbox_LowRPMColor;
-				} else if (rpm >= Setting_Gearbox_Upshift && gear <= MAX_GEAR - 1) {
-					color = Setting_Gearbox_HighRPMColor;
+				if (Setting_Gearbox_Lights_ShowLowHighRPM) {
+					if (rpm <= Setting_Gearbox_Downshift && gear >= 2) {
+						color = Setting_Gearbox_LowRPMColor;
+					} else if (rpm >= Setting_Gearbox_Upshift && gear <= MAX_GEAR - 1) {
+						color = Setting_Gearbox_HighRPMColor;
+					}
 				}
 
 				float lightPadding = 8.0f;

--- a/Source/Things/Gearbox.as
+++ b/Source/Things/Gearbox.as
@@ -235,6 +235,12 @@ class DashboardGearbox : DashboardThing
 					color = GearColor(gear);
 				}
 
+				if (rpm <= Setting_Gearbox_Downshift && gear >= 2) {
+					color = Setting_Gearbox_LowRPMColor;
+				} else if (rpm >= Setting_Gearbox_Upshift && gear <= MAX_GEAR - 1) {
+					color = Setting_Gearbox_HighRPMColor;
+				}
+
 				float lightPadding = 8.0f;
 				float spaceForPadding = lightPadding * float(MAX_GEAR + 1);
 				float lightSize = (size.x - spaceForPadding) / float(MAX_GEAR);

--- a/Source/Things/Gearbox.as
+++ b/Source/Things/Gearbox.as
@@ -1,11 +1,3 @@
-#if MP4
-const uint MAX_GEAR = 7;
-#elif TURBO
-const uint MAX_GEAR = 9;
-#else
-const uint MAX_GEAR = 5;
-#endif
-
 class DashboardGearbox : DashboardThing
 {
 	float m_minRpm = 200.0f; // Minimal RPM to avoid flickering at engine idle
@@ -226,8 +218,16 @@ class DashboardGearbox : DashboardThing
 				uint lights = gear;
 				vec4 color = Setting_Gearbox_Lights_Color;
 
+#if MP4
+				const uint gearCount = 7;
+#elif TURBO
+				const uint gearCount = 9;
+#else
+				const uint gearCount = 5;
+#endif
+
 				if (gear == 0) {
-					lights = MAX_GEAR;
+					lights = gearCount;
 					color = Setting_Gearbox_Lights_Color_Reverse;
 				}
 
@@ -238,16 +238,16 @@ class DashboardGearbox : DashboardThing
 				if (Setting_Gearbox_Lights_ShowLowHighRPM) {
 					if (rpm <= Setting_Gearbox_Downshift && gear >= 2) {
 						color = Setting_Gearbox_LowRPMColor;
-					} else if (rpm >= Setting_Gearbox_Upshift && gear <= MAX_GEAR - 1) {
+					} else if (rpm >= Setting_Gearbox_Upshift && gear <= gearCount - 1) {
 						color = Setting_Gearbox_HighRPMColor;
 					}
 				}
 
 				float lightPadding = 8.0f;
-				float spaceForPadding = lightPadding * float(MAX_GEAR + 1);
-				float lightSize = (size.x - spaceForPadding) / float(MAX_GEAR);
+				float spaceForPadding = lightPadding * float(gearCount + 1);
+				float lightSize = (size.x - spaceForPadding) / float(gearCount);
 
-				for (uint i = 0; i < MAX_GEAR; i++) {
+				for (uint i = 0; i < gearCount; i++) {
 					nvg::BeginPath();
 					nvg::RoundedRect(
 						pos.x + (i + 1) * lightPadding + i * lightSize,


### PR DESCRIPTION
Hello! This is intended to emulate the gear lights on the back of the car. I think this is a little easier to parse than the gear number text. In the future it might be worth copying how car status (turbo, cruise control, etc) change the gear lights.



[Trackmania_2025-11-13_16-00-33 (online-video-cutter.com).webm](https://github.com/user-attachments/assets/84215d4c-c98a-43a3-a7f7-6b3e2faab13e)
