### PR TITLE
input display text

### DIFF
--- a/Source/Pads/Gamepad.as
+++ b/Source/Pads/Gamepad.as
@@ -1,5 +1,31 @@
 class DashboardPadGamepad : IDashboardPad
 {
+	nvg::Font m_font;
+	string m_fontPath;
+
+	DashboardPadGamepad()
+	{
+		LoadFont();
+	}
+
+	void LoadFont()
+	{
+		if (Setting_Gamepad_Font == m_fontPath) {
+			return;
+		}
+
+		auto font = nvg::LoadFont(Setting_Gamepad_Font);
+		if (font >= 0) {
+			m_fontPath = Setting_Gamepad_Font;
+			m_font = font;
+		}
+	}
+
+	void OnSettingsChanged() override
+	{
+		LoadFont();
+	}
+
 	void RenderUniform(const vec2 &in size, CSceneVehicleVisState@ vis)
 	{
 		float leftSize = size.x * (0.5f - Setting_Gamepad_MiddleScale / 2) - Setting_Gamepad_Spacing;
@@ -123,7 +149,7 @@ class DashboardPadGamepad : IDashboardPad
 
 		// Steering percentage
 		if (Setting_Gamepad_SteerPercentage) {
-			nvg::FontFace(g_font);
+			nvg::FontFace(m_font);
 			nvg::FontSize(Setting_Gamepad_SteerPercentageSize);
 			nvg::FillColor(Setting_Gamepad_TextColor);
 

--- a/Source/Pads/Gamepad.as
+++ b/Source/Pads/Gamepad.as
@@ -157,14 +157,14 @@ class DashboardPadGamepad : IDashboardPad
 			if (steerLeft > 0) {
 				nvg::BeginPath();
 				nvg::TextAlign(nvg::Align::Middle | nvg::Align::Right);
-				nvg::TextBox(0, size.y / 2, leftSize - Setting_Gamepad_Spacing, tostring(Math::Round(steerLeft * 100)) + "%");
+				nvg::TextBox(0, size.y / 2, leftSize - Setting_Gamepad_Spacing, Text::Format("%.f%%", steerLeft * 100.0f));
 			}
 
 			// Right
 			if (steerRight > 0) {
 				nvg::BeginPath();
 				nvg::TextAlign(nvg::Align::Middle | nvg::Align::Left);
-				nvg::TextBox(rightX + Setting_Gamepad_Spacing, size.y / 2, rightSize, tostring(Math::Round(steerRight * 100)) + "%");
+				nvg::TextBox(rightX + Setting_Gamepad_Spacing, size.y / 2, rightSize, Text::Format("%.f%%", steerRight * 100.0f));
 			}
 		}
 	}

--- a/Source/Pads/Gamepad.as
+++ b/Source/Pads/Gamepad.as
@@ -139,9 +139,9 @@ class DashboardPadGamepad : IDashboardPad
 		// Up & Down texts
 		if (Setting_Gamepad_UpDownSymbols) {
 			nvg::BeginPath();
-			nvg::FontFace(g_font);
-			nvg::FontSize(midSize / 2);
-			nvg::FillColor(Setting_Gamepad_TextColor);
+			nvg::FontFace(m_font);
+			nvg::FontSize(Setting_Gamepad_FontSize * 1.5f);
+			nvg::FillColor(Setting_Gamepad_FontColor);
 			nvg::TextAlign(nvg::Align::Middle | nvg::Align::Center);
 			nvg::TextBox(midX, topSize / 2, midSize, Icons::AngleUp);
 			nvg::TextBox(midX, bottomY + bottomSize / 2, midSize, Icons::AngleDown);
@@ -150,8 +150,8 @@ class DashboardPadGamepad : IDashboardPad
 		// Steering percentage
 		if (Setting_Gamepad_SteerPercentage) {
 			nvg::FontFace(m_font);
-			nvg::FontSize(Setting_Gamepad_SteerPercentageSize);
-			nvg::FillColor(Setting_Gamepad_TextColor);
+			nvg::FontSize(Setting_Gamepad_FontSize);
+			nvg::FillColor(Setting_Gamepad_FontColor);
 
 			// Left
 			if (steerLeft > 0) {

--- a/Source/Pads/Gamepad.as
+++ b/Source/Pads/Gamepad.as
@@ -279,12 +279,12 @@ class DashboardPadGamepad : IDashboardPad
 		if (Setting_Gamepad_SteerPercentage) {
 			nvg::FontFace(m_font);
 			nvg::FontSize(Setting_Gamepad_FontSize);
-			nvg::FillColor(Setting_Gamepad_FontColor);
 
 			// Left
 			if (steerLeft > 0) {
 				nvg::BeginPath();
 				nvg::TextAlign(nvg::Align::Middle | nvg::Align::Right);
+				nvg::FillColor(WithAlpha(Setting_Gamepad_FontColor, Math::Lerp(Setting_Gamepad_OffAlpha, 1.0f, steerLeft)));
 				nvg::TextBox(
 					-Setting_Gamepad_SteerPercentageSpacing,
 					size.y / 2,
@@ -297,6 +297,7 @@ class DashboardPadGamepad : IDashboardPad
 			if (steerRight > 0) {
 				nvg::BeginPath();
 				nvg::TextAlign(nvg::Align::Middle | nvg::Align::Left);
+				nvg::FillColor(WithAlpha(Setting_Gamepad_FontColor, Math::Lerp(Setting_Gamepad_OffAlpha, 1.0f, steerRight)));
 				nvg::TextBox(
 					Setting_Gamepad_SteerPercentageSpacing + rightX + Setting_Gamepad_Spacing,
 					size.y / 2,

--- a/Source/Pads/Gamepad.as
+++ b/Source/Pads/Gamepad.as
@@ -77,6 +77,12 @@ class DashboardPadGamepad : IDashboardPad
 			nvg::Fill();
 			nvg::ResetScissor();
 		}
+		float fillAlphaLeft = Math::Lerp(Setting_Gamepad_OffAlpha, 1.0f, steerLeft);
+		if (Setting_Gamepad_UseBorderGradient) {
+			nvg::StrokePaint(Setting_Gamepad_BorderGradient.GetPaint(vec2(), size, fillAlphaLeft));
+		} else {
+			nvg::StrokeColor(Setting_Gamepad_BorderColor);
+		}
 		nvg::Stroke();
 
 		// Right
@@ -98,6 +104,12 @@ class DashboardPadGamepad : IDashboardPad
 			nvg::Fill();
 			nvg::ResetScissor();
 		}
+		float fillAlphaRight = Math::Lerp(Setting_Gamepad_OffAlpha, 1.0f, steerRight);
+		if (Setting_Gamepad_UseBorderGradient) {
+			nvg::StrokePaint(Setting_Gamepad_BorderGradient.GetPaint(vec2(), size, fillAlphaRight));
+		} else {
+			nvg::StrokeColor(Setting_Gamepad_BorderColor);
+		}
 		nvg::Stroke();
 
 		// Up
@@ -115,6 +127,12 @@ class DashboardPadGamepad : IDashboardPad
 			}
 			nvg::Fill();
 			nvg::ResetScissor();
+		}
+		float fillAlphaUp = pedalGas > 0.1f ? 1.0f : Setting_Gamepad_OffAlpha;
+		if (Setting_Gamepad_UseBorderGradient) {
+			nvg::StrokePaint(Setting_Gamepad_BorderGradient.GetPaint(vec2(), size, fillAlphaUp));
+		} else {
+			nvg::StrokeColor(Setting_Gamepad_BorderColor);
 		}
 		nvg::Stroke();
 
@@ -134,6 +152,12 @@ class DashboardPadGamepad : IDashboardPad
 			nvg::Fill();
 			nvg::ResetScissor();
 		}
+		float fillAlphaDown = pedalBrake > 0.1f ? 1.0f : Setting_Gamepad_OffAlpha;
+		if (Setting_Gamepad_UseBorderGradient) {
+			nvg::StrokePaint(Setting_Gamepad_BorderGradient.GetPaint(vec2(), size, fillAlphaDown));
+		} else {
+			nvg::StrokeColor(Setting_Gamepad_BorderColor);
+		}
 		nvg::Stroke();
 
 		// Up & Down texts
@@ -141,9 +165,10 @@ class DashboardPadGamepad : IDashboardPad
 			nvg::BeginPath();
 			nvg::FontFace(m_font);
 			nvg::FontSize(Setting_Gamepad_FontSize * 1.5f);
-			nvg::FillColor(Setting_Gamepad_FontColor);
 			nvg::TextAlign(nvg::Align::Middle | nvg::Align::Center);
+			nvg::FillColor(WithAlpha(Setting_Gamepad_FontColor, fillAlphaUp));
 			nvg::TextBox(midX, topSize / 2, midSize, Icons::AngleUp);
+			nvg::FillColor(WithAlpha(Setting_Gamepad_FontColor, fillAlphaDown));
 			nvg::TextBox(midX, bottomY + bottomSize / 2, midSize, Icons::AngleDown);
 		}
 
@@ -151,12 +176,12 @@ class DashboardPadGamepad : IDashboardPad
 		if (Setting_Gamepad_SteerPercentage) {
 			nvg::FontFace(m_font);
 			nvg::FontSize(Setting_Gamepad_FontSize);
-			nvg::FillColor(Setting_Gamepad_FontColor);
 
 			// Left
 			if (steerLeft > 0) {
 				nvg::BeginPath();
 				nvg::TextAlign(nvg::Align::Middle | nvg::Align::Right);
+				nvg::FillColor(WithAlpha(Setting_Gamepad_FontColor, fillAlphaLeft));
 				nvg::TextBox(
 					-Setting_Gamepad_SteerPercentageSpacing,
 					size.y / 2,
@@ -169,6 +194,7 @@ class DashboardPadGamepad : IDashboardPad
 			if (steerRight > 0) {
 				nvg::BeginPath();
 				nvg::TextAlign(nvg::Align::Middle | nvg::Align::Left);
+				nvg::FillColor(WithAlpha(Setting_Gamepad_FontColor, fillAlphaRight));
 				nvg::TextBox(
 					Setting_Gamepad_SteerPercentageSpacing + rightX + Setting_Gamepad_Spacing,
 					size.y / 2,

--- a/Source/Pads/Gamepad.as
+++ b/Source/Pads/Gamepad.as
@@ -166,9 +166,9 @@ class DashboardPadGamepad : IDashboardPad
 			nvg::FontFace(m_font);
 			nvg::FontSize(Setting_Gamepad_FontSize * 1.5f);
 			nvg::TextAlign(nvg::Align::Middle | nvg::Align::Center);
-			nvg::FillColor(WithAlpha(Setting_Gamepad_TextColor, fillAlphaUp));
+			nvg::FillColor(WithAlpha(Setting_Gamepad_TextColor, Setting_Gamepad_OffAlphaText ? fillAlphaUp : 1.0f));
 			nvg::TextBox(midX, topSize / 2, midSize, Icons::AngleUp);
-			nvg::FillColor(WithAlpha(Setting_Gamepad_TextColor, fillAlphaDown));
+			nvg::FillColor(WithAlpha(Setting_Gamepad_TextColor, Setting_Gamepad_OffAlphaText ? fillAlphaDown : 1.0f));
 			nvg::TextBox(midX, bottomY + bottomSize / 2, midSize, Icons::AngleDown);
 		}
 
@@ -181,7 +181,7 @@ class DashboardPadGamepad : IDashboardPad
 			if (steerLeft > 0) {
 				nvg::BeginPath();
 				nvg::TextAlign(nvg::Align::Middle | nvg::Align::Right);
-				nvg::FillColor(WithAlpha(Setting_Gamepad_TextColor, fillAlphaLeft));
+				nvg::FillColor(WithAlpha(Setting_Gamepad_TextColor, Setting_Gamepad_OffAlphaText ? fillAlphaLeft : 1.0f));
 				nvg::TextBox(
 					-Setting_Gamepad_SteerPercentageSpacing,
 					size.y / 2,
@@ -194,7 +194,7 @@ class DashboardPadGamepad : IDashboardPad
 			if (steerRight > 0) {
 				nvg::BeginPath();
 				nvg::TextAlign(nvg::Align::Middle | nvg::Align::Left);
-				nvg::FillColor(WithAlpha(Setting_Gamepad_TextColor, fillAlphaRight));
+				nvg::FillColor(WithAlpha(Setting_Gamepad_TextColor, Setting_Gamepad_OffAlphaText ? fillAlphaRight : 1.0f));
 				nvg::TextBox(
 					Setting_Gamepad_SteerPercentageSpacing + rightX + Setting_Gamepad_Spacing,
 					size.y / 2,
@@ -275,6 +275,8 @@ class DashboardPadGamepad : IDashboardPad
 		nvg::Fill();
 		nvg::ResetScissor();
 
+		float textAlpha = Setting_Gamepad_OffAlphaText ? Setting_Gamepad_OffAlpha : 1.0f;
+
 		// Steering percentage
 		if (Setting_Gamepad_SteerPercentage) {
 			nvg::FontFace(m_font);
@@ -284,7 +286,7 @@ class DashboardPadGamepad : IDashboardPad
 			if (steerLeft > 0) {
 				nvg::BeginPath();
 				nvg::TextAlign(nvg::Align::Middle | nvg::Align::Right);
-				nvg::FillColor(WithAlpha(Setting_Gamepad_TextColor, Math::Lerp(Setting_Gamepad_OffAlpha, 1.0f, steerLeft)));
+				nvg::FillColor(WithAlpha(Setting_Gamepad_TextColor, Math::Lerp(textAlpha, 1.0f, steerLeft)));
 				nvg::TextBox(
 					-Setting_Gamepad_SteerPercentageSpacing,
 					size.y / 2,
@@ -297,7 +299,7 @@ class DashboardPadGamepad : IDashboardPad
 			if (steerRight > 0) {
 				nvg::BeginPath();
 				nvg::TextAlign(nvg::Align::Middle | nvg::Align::Left);
-				nvg::FillColor(WithAlpha(Setting_Gamepad_TextColor, Math::Lerp(Setting_Gamepad_OffAlpha, 1.0f, steerRight)));
+				nvg::FillColor(WithAlpha(Setting_Gamepad_TextColor, Math::Lerp(textAlpha, 1.0f, steerRight)));
 				nvg::TextBox(
 					Setting_Gamepad_SteerPercentageSpacing + rightX + Setting_Gamepad_Spacing,
 					size.y / 2,

--- a/Source/Pads/Gamepad.as
+++ b/Source/Pads/Gamepad.as
@@ -166,9 +166,9 @@ class DashboardPadGamepad : IDashboardPad
 			nvg::FontFace(m_font);
 			nvg::FontSize(Setting_Gamepad_FontSize * 1.5f);
 			nvg::TextAlign(nvg::Align::Middle | nvg::Align::Center);
-			nvg::FillColor(WithAlpha(Setting_Gamepad_FontColor, fillAlphaUp));
+			nvg::FillColor(WithAlpha(Setting_Gamepad_TextColor, fillAlphaUp));
 			nvg::TextBox(midX, topSize / 2, midSize, Icons::AngleUp);
-			nvg::FillColor(WithAlpha(Setting_Gamepad_FontColor, fillAlphaDown));
+			nvg::FillColor(WithAlpha(Setting_Gamepad_TextColor, fillAlphaDown));
 			nvg::TextBox(midX, bottomY + bottomSize / 2, midSize, Icons::AngleDown);
 		}
 
@@ -181,7 +181,7 @@ class DashboardPadGamepad : IDashboardPad
 			if (steerLeft > 0) {
 				nvg::BeginPath();
 				nvg::TextAlign(nvg::Align::Middle | nvg::Align::Right);
-				nvg::FillColor(WithAlpha(Setting_Gamepad_FontColor, fillAlphaLeft));
+				nvg::FillColor(WithAlpha(Setting_Gamepad_TextColor, fillAlphaLeft));
 				nvg::TextBox(
 					-Setting_Gamepad_SteerPercentageSpacing,
 					size.y / 2,
@@ -194,7 +194,7 @@ class DashboardPadGamepad : IDashboardPad
 			if (steerRight > 0) {
 				nvg::BeginPath();
 				nvg::TextAlign(nvg::Align::Middle | nvg::Align::Left);
-				nvg::FillColor(WithAlpha(Setting_Gamepad_FontColor, fillAlphaRight));
+				nvg::FillColor(WithAlpha(Setting_Gamepad_TextColor, fillAlphaRight));
 				nvg::TextBox(
 					Setting_Gamepad_SteerPercentageSpacing + rightX + Setting_Gamepad_Spacing,
 					size.y / 2,
@@ -284,7 +284,7 @@ class DashboardPadGamepad : IDashboardPad
 			if (steerLeft > 0) {
 				nvg::BeginPath();
 				nvg::TextAlign(nvg::Align::Middle | nvg::Align::Right);
-				nvg::FillColor(WithAlpha(Setting_Gamepad_FontColor, Math::Lerp(Setting_Gamepad_OffAlpha, 1.0f, steerLeft)));
+				nvg::FillColor(WithAlpha(Setting_Gamepad_TextColor, Math::Lerp(Setting_Gamepad_OffAlpha, 1.0f, steerLeft)));
 				nvg::TextBox(
 					-Setting_Gamepad_SteerPercentageSpacing,
 					size.y / 2,
@@ -297,7 +297,7 @@ class DashboardPadGamepad : IDashboardPad
 			if (steerRight > 0) {
 				nvg::BeginPath();
 				nvg::TextAlign(nvg::Align::Middle | nvg::Align::Left);
-				nvg::FillColor(WithAlpha(Setting_Gamepad_FontColor, Math::Lerp(Setting_Gamepad_OffAlpha, 1.0f, steerRight)));
+				nvg::FillColor(WithAlpha(Setting_Gamepad_TextColor, Math::Lerp(Setting_Gamepad_OffAlpha, 1.0f, steerRight)));
 				nvg::TextBox(
 					Setting_Gamepad_SteerPercentageSpacing + rightX + Setting_Gamepad_Spacing,
 					size.y / 2,

--- a/Source/Pads/Gamepad.as
+++ b/Source/Pads/Gamepad.as
@@ -393,6 +393,46 @@ class DashboardPadGamepad : IDashboardPad
 		nvg::FillColor(pedalBrake > 0.1f ? Setting_Gamepad_FillColor : Setting_Gamepad_EmptyFillColor);
 		FillInflectedTriangle(posMidBot, posBotInflection, posMidLeft, posMidRight);
 		StrokeInflectedTriangle(posMidBot, posBotInflection, posMidLeft, posMidRight);
+
+		float textAlpha = Setting_Gamepad_OffAlphaText ? Setting_Gamepad_OffAlpha : 1.0f;
+
+		float leftSize = size.x * (0.5f - Setting_Gamepad_MiddleScale / 2) - Setting_Gamepad_Spacing;
+		float midX = leftSize + Setting_Gamepad_Spacing;
+		float midSize = size.x * Setting_Gamepad_MiddleScale;
+		float rightX = midX + midSize + Setting_Gamepad_Spacing;
+		float rightSize = size.x - rightX;
+
+		// Steering percentage
+		if (Setting_Gamepad_SteerPercentage) {
+			nvg::FontFace(m_font);
+			nvg::FontSize(Setting_Gamepad_FontSize);
+
+			// Left
+			if (steerLeft > 0) {
+				nvg::BeginPath();
+				nvg::TextAlign(nvg::Align::Middle | nvg::Align::Right);
+				nvg::FillColor(WithAlpha(Setting_Gamepad_TextColor, Math::Lerp(textAlpha, 1.0f, steerLeft)));
+				nvg::TextBox(
+					-Setting_Gamepad_SteerPercentageSpacing,
+					size.y / 2,
+					leftSize - Setting_Gamepad_Spacing,
+					Text::Format("%.f" + (Setting_Gamepad_SteerPercentageSymbol ? "%%" : ""), steerLeft * 100.0f)
+				);
+			}
+
+			// Right
+			if (steerRight > 0) {
+				nvg::BeginPath();
+				nvg::TextAlign(nvg::Align::Middle | nvg::Align::Left);
+				nvg::FillColor(WithAlpha(Setting_Gamepad_TextColor, Math::Lerp(textAlpha, 1.0f, steerRight)));
+				nvg::TextBox(
+					Setting_Gamepad_SteerPercentageSpacing + rightX + Setting_Gamepad_Spacing,
+					size.y / 2,
+					rightSize,
+					Text::Format("%.f" + (Setting_Gamepad_SteerPercentageSymbol ? "%%" : ""), steerRight * 100.0f)
+				);
+			}
+		}
 	}
 
 	private void FillInflectedTriangle(const vec2 &in posApex, const vec2 &in posInflection, const vec2 &in posSide1, const vec2 &in posSide2)

--- a/Source/Pads/Gamepad.as
+++ b/Source/Pads/Gamepad.as
@@ -238,6 +238,27 @@ class DashboardPadGamepad : IDashboardPad
 		nvg::FillColor(WithAlpha(Setting_Gamepad_ClassicDownColor, pedalBrake > 0.1f ? 1.0f : Setting_Gamepad_OffAlpha));
 		nvg::Fill();
 		nvg::ResetScissor();
+
+		// Steering percentage
+		if (Setting_Gamepad_SteerPercentage) {
+			nvg::FontFace(m_font);
+			nvg::FontSize(Setting_Gamepad_FontSize);
+			nvg::FillColor(Setting_Gamepad_FontColor);
+
+			// Left
+			if (steerLeft > 0) {
+				nvg::BeginPath();
+				nvg::TextAlign(nvg::Align::Middle | nvg::Align::Right);
+				nvg::TextBox(0, size.y / 2, leftSize - Setting_Gamepad_Spacing, Text::Format("%.f%%", steerLeft * 100.0f));
+			}
+
+			// Right
+			if (steerRight > 0) {
+				nvg::BeginPath();
+				nvg::TextAlign(nvg::Align::Middle | nvg::Align::Left);
+				nvg::TextBox(rightX + Setting_Gamepad_Spacing, size.y / 2, rightSize, Text::Format("%.f%%", steerRight * 100.0f));
+			}
+		}
 	}
 
 	void RenderCateye(const vec2 &in size, CSceneVehicleVisState@ vis)

--- a/Source/Pads/Gamepad.as
+++ b/Source/Pads/Gamepad.as
@@ -157,14 +157,24 @@ class DashboardPadGamepad : IDashboardPad
 			if (steerLeft > 0) {
 				nvg::BeginPath();
 				nvg::TextAlign(nvg::Align::Middle | nvg::Align::Right);
-				nvg::TextBox(0, size.y / 2, leftSize - Setting_Gamepad_Spacing, Text::Format("%.f%%", steerLeft * 100.0f));
+				nvg::TextBox(
+					-Setting_Gamepad_SteerPercentageSpacing,
+					size.y / 2,
+					leftSize - Setting_Gamepad_Spacing,
+					Text::Format("%.f" + (Setting_Gamepad_SteerPercentageSymbol ? "%%" : ""), steerLeft * 100.0f)
+				);
 			}
 
 			// Right
 			if (steerRight > 0) {
 				nvg::BeginPath();
 				nvg::TextAlign(nvg::Align::Middle | nvg::Align::Left);
-				nvg::TextBox(rightX + Setting_Gamepad_Spacing, size.y / 2, rightSize, Text::Format("%.f%%", steerRight * 100.0f));
+				nvg::TextBox(
+					Setting_Gamepad_SteerPercentageSpacing + rightX + Setting_Gamepad_Spacing,
+					size.y / 2,
+					rightSize,
+					Text::Format("%.f" + (Setting_Gamepad_SteerPercentageSymbol ? "%%" : ""), steerRight * 100.0f)
+				);
 			}
 		}
 	}
@@ -249,14 +259,24 @@ class DashboardPadGamepad : IDashboardPad
 			if (steerLeft > 0) {
 				nvg::BeginPath();
 				nvg::TextAlign(nvg::Align::Middle | nvg::Align::Right);
-				nvg::TextBox(0, size.y / 2, leftSize - Setting_Gamepad_Spacing, Text::Format("%.f%%", steerLeft * 100.0f));
+				nvg::TextBox(
+					-Setting_Gamepad_SteerPercentageSpacing,
+					size.y / 2,
+					leftSize - Setting_Gamepad_Spacing,
+					Text::Format("%.f" + (Setting_Gamepad_SteerPercentageSymbol ? "%%" : ""), steerLeft * 100.0f)
+				);
 			}
 
 			// Right
 			if (steerRight > 0) {
 				nvg::BeginPath();
 				nvg::TextAlign(nvg::Align::Middle | nvg::Align::Left);
-				nvg::TextBox(rightX + Setting_Gamepad_Spacing, size.y / 2, rightSize, Text::Format("%.f%%", steerRight * 100.0f));
+				nvg::TextBox(
+					Setting_Gamepad_SteerPercentageSpacing + rightX + Setting_Gamepad_Spacing,
+					size.y / 2,
+					rightSize,
+					Text::Format("%.f" + (Setting_Gamepad_SteerPercentageSymbol ? "%%" : ""), steerRight * 100.0f)
+				);
 			}
 		}
 	}

--- a/Source/Pads/Gamepad.as
+++ b/Source/Pads/Gamepad.as
@@ -164,7 +164,7 @@ class DashboardPadGamepad : IDashboardPad
 		if (Setting_Gamepad_UpDownSymbols) {
 			nvg::BeginPath();
 			nvg::FontFace(m_font);
-			nvg::FontSize(Setting_Gamepad_FontSize * 1.5f);
+			nvg::FontSize(Setting_Gamepad_SteerPercentageSize * 1.5f);
 			nvg::TextAlign(nvg::Align::Middle | nvg::Align::Center);
 			nvg::FillColor(WithAlpha(Setting_Gamepad_TextColor, Setting_Gamepad_OffAlphaText ? fillAlphaUp : 1.0f));
 			nvg::TextBox(midX, topSize / 2, midSize, Icons::AngleUp);
@@ -175,7 +175,7 @@ class DashboardPadGamepad : IDashboardPad
 		// Steering percentage
 		if (Setting_Gamepad_SteerPercentage) {
 			nvg::FontFace(m_font);
-			nvg::FontSize(Setting_Gamepad_FontSize);
+			nvg::FontSize(Setting_Gamepad_SteerPercentageSize);
 
 			// Left
 			if (steerLeft > 0) {
@@ -280,7 +280,7 @@ class DashboardPadGamepad : IDashboardPad
 		// Steering percentage
 		if (Setting_Gamepad_SteerPercentage) {
 			nvg::FontFace(m_font);
-			nvg::FontSize(Setting_Gamepad_FontSize);
+			nvg::FontSize(Setting_Gamepad_SteerPercentageSize);
 
 			// Left
 			if (steerLeft > 0) {
@@ -405,7 +405,7 @@ class DashboardPadGamepad : IDashboardPad
 		// Steering percentage
 		if (Setting_Gamepad_SteerPercentage) {
 			nvg::FontFace(m_font);
-			nvg::FontSize(Setting_Gamepad_FontSize);
+			nvg::FontSize(Setting_Gamepad_SteerPercentageSize);
 
 			// Left
 			if (steerLeft > 0) {

--- a/Source/Pads/Keyboard.as
+++ b/Source/Pads/Keyboard.as
@@ -95,8 +95,13 @@ class DashboardPadKeyboard : IDashboardPad
 		nvg::FontFace(g_font);
 		nvg::FontSize(size.x / 2);
 		nvg::FillColor(Setting_Keyboard_TextColor);
-		if (Setting_Keyboard_ArrowSymbols) {
-			nvg::TextAlign(nvg::Align::Middle | nvg::Align::Center);
+		nvg::TextAlign(nvg::Align::Middle | nvg::Align::Center);
+		if (Setting_Keyboard_SteerPercentage && fillDir != 0) {
+			if (value > 0.0f) {
+				nvg::FontSize(Setting_Keyboard_SteerPercentageSize);
+				nvg::TextBox(pos.x, pos.y + size.y / 2, size.x, tostring(Math::Round(value * 100)) + "%");
+			}
+		} else if (Setting_Keyboard_ArrowSymbols) {
 			nvg::TextBox(pos.x, pos.y + size.y / 2, size.x, text);
 		}
 	}

--- a/Source/Pads/Keyboard.as
+++ b/Source/Pads/Keyboard.as
@@ -94,11 +94,7 @@ class DashboardPadKeyboard : IDashboardPad
 		nvg::BeginPath();
 		nvg::FontFace(g_font);
 		nvg::FontSize(size.x / 2);
-		if (Setting_Keyboard_UseBorderGradient) {
-			nvg::FillPaint(Setting_Keyboard_BorderGradient.GetPaint(vec2(), m_size, fillAlpha));
-		} else {
-			nvg::FillColor(borderColor);
-		}
+		nvg::FillColor(Setting_Keyboard_TextColor);
 		if (Setting_Keyboard_ArrowSymbols) {
 			nvg::TextAlign(nvg::Align::Middle | nvg::Align::Center);
 			nvg::TextBox(pos.x, pos.y + size.y / 2, size.x, text);

--- a/Source/Pads/Keyboard.as
+++ b/Source/Pads/Keyboard.as
@@ -99,7 +99,9 @@ class DashboardPadKeyboard : IDashboardPad
 		} else {
 			nvg::FillColor(borderColor);
 		}
-		nvg::TextAlign(nvg::Align::Middle | nvg::Align::Center);
-		nvg::TextBox(pos.x, pos.y + size.y / 2, size.x, text);
+		if (Setting_Keyboard_ArrowSymbols) {
+			nvg::TextAlign(nvg::Align::Middle | nvg::Align::Center);
+			nvg::TextBox(pos.x, pos.y + size.y / 2, size.x, text);
+		}
 	}
 }

--- a/Source/Pads/Keyboard.as
+++ b/Source/Pads/Keyboard.as
@@ -125,7 +125,7 @@ class DashboardPadKeyboard : IDashboardPad
 		if (Setting_Keyboard_SteerPercentage && fillDir != 0) {
 			if (value > 0.0f) {
 				nvg::FontSize(Setting_Keyboard_SteerPercentageSize);
-				nvg::TextBox(pos.x, pos.y + size.y / 2, size.x, tostring(Math::Round(value * 100)) + "%");
+				nvg::TextBox(pos.x, pos.y + size.y / 2, size.x, Text::Format("%.f%%", value * 100.0f));
 			}
 		} else if (Setting_Keyboard_ArrowSymbols) {
 			nvg::TextBox(pos.x, pos.y + size.y / 2, size.x, text);

--- a/Source/Pads/Keyboard.as
+++ b/Source/Pads/Keyboard.as
@@ -1,6 +1,32 @@
 class DashboardPadKeyboard : IDashboardPad
 {
+	nvg::Font m_font;
+	string m_fontPath;
+
 	vec2 m_size;
+
+	DashboardPadKeyboard()
+	{
+		LoadFont();
+	}
+
+	void LoadFont()
+	{
+		if (Setting_Keyboard_Font == m_fontPath) {
+			return;
+		}
+
+		auto font = nvg::LoadFont(Setting_Keyboard_Font);
+		if (font >= 0) {
+			m_fontPath = Setting_Keyboard_Font;
+			m_font = font;
+		}
+	}
+
+	void OnSettingsChanged() override
+	{
+		LoadFont();
+	}
 
 	void Render(const vec2 &in size, CSceneVehicleVisState@ vis) override
 	{
@@ -92,7 +118,7 @@ class DashboardPadKeyboard : IDashboardPad
 		nvg::Stroke();
 
 		nvg::BeginPath();
-		nvg::FontFace(g_font);
+		nvg::FontFace(m_font);
 		nvg::FontSize(size.x / 2);
 		nvg::FillColor(Setting_Keyboard_TextColor);
 		nvg::TextAlign(nvg::Align::Middle | nvg::Align::Center);

--- a/Source/Pads/Keyboard.as
+++ b/Source/Pads/Keyboard.as
@@ -117,10 +117,13 @@ class DashboardPadKeyboard : IDashboardPad
 		}
 		nvg::Stroke();
 
+		vec4 textColor = Setting_Keyboard_TextColor;
+		textColor.w *= fillAlpha;
+
 		nvg::BeginPath();
 		nvg::FontFace(m_font);
 		nvg::FontSize(size.x / 2);
-		nvg::FillColor(Setting_Keyboard_TextColor);
+		nvg::FillColor(textColor);
 		nvg::TextAlign(nvg::Align::Middle | nvg::Align::Center);
 		if (Setting_Keyboard_SteerPercentage && fillDir != 0) {
 			if (value > 0.0f) {

--- a/Source/Pads/Keyboard.as
+++ b/Source/Pads/Keyboard.as
@@ -127,7 +127,12 @@ class DashboardPadKeyboard : IDashboardPad
 		if (Setting_Keyboard_SteerPercentage && fillDir != 0) {
 			if (value > 0.0f) {
 				nvg::FontSize(Setting_Keyboard_FontSize);
-				nvg::TextBox(pos.x, pos.y + size.y / 2, size.x, Text::Format("%.f%%", value * 100.0f));
+				nvg::TextBox(
+					pos.x,
+					pos.y + size.y / 2,
+					size.x,
+					Text::Format("%.f" + (Setting_Keyboard_SteerPercentageSymbol ? "%%" : ""), value * 100.0f)
+				);
 			}
 		} else if (Setting_Keyboard_ArrowSymbols) {
 			nvg::FontSize(Setting_Keyboard_FontSize * 1.5f);

--- a/Source/Pads/Keyboard.as
+++ b/Source/Pads/Keyboard.as
@@ -117,20 +117,20 @@ class DashboardPadKeyboard : IDashboardPad
 		}
 		nvg::Stroke();
 
-		vec4 textColor = Setting_Keyboard_TextColor;
+		vec4 textColor = Setting_Keyboard_FontColor;
 		textColor.w *= fillAlpha;
 
 		nvg::BeginPath();
 		nvg::FontFace(m_font);
-		nvg::FontSize(size.x / 2);
 		nvg::FillColor(textColor);
 		nvg::TextAlign(nvg::Align::Middle | nvg::Align::Center);
 		if (Setting_Keyboard_SteerPercentage && fillDir != 0) {
 			if (value > 0.0f) {
-				nvg::FontSize(Setting_Keyboard_SteerPercentageSize);
+				nvg::FontSize(Setting_Keyboard_FontSize);
 				nvg::TextBox(pos.x, pos.y + size.y / 2, size.x, Text::Format("%.f%%", value * 100.0f));
 			}
 		} else if (Setting_Keyboard_ArrowSymbols) {
+			nvg::FontSize(Setting_Keyboard_FontSize * 1.5f);
 			nvg::TextBox(pos.x, pos.y + size.y / 2, size.x, text);
 		}
 	}

--- a/Source/Pads/Keyboard.as
+++ b/Source/Pads/Keyboard.as
@@ -117,7 +117,7 @@ class DashboardPadKeyboard : IDashboardPad
 		}
 		nvg::Stroke();
 
-		vec4 textColor = Setting_Keyboard_FontColor;
+		vec4 textColor = Setting_Keyboard_TextColor;
 		textColor.w *= fillAlpha;
 
 		nvg::BeginPath();

--- a/Source/Pads/Keyboard.as
+++ b/Source/Pads/Keyboard.as
@@ -118,7 +118,9 @@ class DashboardPadKeyboard : IDashboardPad
 		nvg::Stroke();
 
 		vec4 textColor = Setting_Keyboard_TextColor;
-		textColor.w *= fillAlpha;
+		if (Setting_Gamepad_InactiveAlphaText) {
+			textColor.w *= fillAlpha;
+		}
 
 		nvg::BeginPath();
 		nvg::FontFace(m_font);

--- a/Source/Settings.as
+++ b/Source/Settings.as
@@ -135,6 +135,9 @@ bool Setting_Gamepad_SteerPercentage = false;
 	if="Setting_Gamepad_Style Uniform"]
 int Setting_Gamepad_SteerPercentageSize = 16;
 
+[Setting category="Gamepad" name="Font" if="Setting_Gamepad_Style Uniform"]
+string Setting_Gamepad_Font = "DroidSans.ttf";
+
 [Setting category="Gamepad" name="Text and symbol color" color if="Setting_Gamepad_Style Uniform"]
 vec4 Setting_Gamepad_TextColor = vec4(1, 1, 1, 1);
 
@@ -194,6 +197,9 @@ bool Setting_Keyboard_SteerPercentage = false;
 	name="Steer percentage size"
 	drag min=2 max=40]
 int Setting_Keyboard_SteerPercentageSize = 16;
+
+[Setting category="Keyboard" name="Font"]
+string Setting_Keyboard_Font = "DroidSans.ttf";
 
 [Setting category="Keyboard" name="Text and symbol color" color]
 vec4 Setting_Keyboard_TextColor = vec4(1, 1, 1, 1);

--- a/Source/Settings.as
+++ b/Source/Settings.as
@@ -125,20 +125,20 @@ bool Setting_Gamepad_UpDownSymbols = true;
 [Setting category="Gamepad" name="Cateye use simple steer" if="Setting_Gamepad_Style Cateye"]
 bool Setting_Gamepad_CateyeUseSimpleSteer = false;
 
-[Setting category="Gamepad" name="Display steer percentage" if="Setting_Gamepad_Style Uniform"]
+[Setting category="Gamepad" name="Display steer percentage" if="!Setting_Gamepad_Style Cateye"]
 bool Setting_Gamepad_SteerPercentage = false;
 
-[Setting category="Gamepad" name="Font" if="Setting_Gamepad_Style Uniform"]
+[Setting category="Gamepad" name="Font" if="!Setting_Gamepad_Style Cateye"]
 string Setting_Gamepad_Font = "DroidSans.ttf";
 
 [Setting
 	category="Gamepad"
 	name="Font size"
 	min=2 max=40
-	if="Setting_Gamepad_Style Uniform"]
+	if="!Setting_Gamepad_Style Cateye"]
 int Setting_Gamepad_FontSize = 16;
 
-[Setting category="Gamepad" name="Font color" color if="Setting_Gamepad_Style Uniform"]
+[Setting category="Gamepad" name="Font color" color if="!Setting_Gamepad_Style Cateye"]
 vec4 Setting_Gamepad_FontColor = vec4(1, 1, 1, 1);
 
 

--- a/Source/Settings.as
+++ b/Source/Settings.as
@@ -128,6 +128,12 @@ bool Setting_Gamepad_CateyeUseSimpleSteer = false;
 [Setting category="Gamepad" name="Display steer percentage" if="!Setting_Gamepad_Style Cateye"]
 bool Setting_Gamepad_SteerPercentage = false;
 
+[Setting category="Gamepad" name="Display steer percentage symbol" if="!Setting_Gamepad_Style Cateye"]
+bool Setting_Gamepad_SteerPercentageSymbol = true;
+
+[Setting category="Gamepad" name="Steer percentage spacing" min=-100 max=100 if="!Setting_Gamepad_Style Cateye"]
+float Setting_Gamepad_SteerPercentageSpacing = 0.0f;
+
 [Setting category="Gamepad" name="Font" if="!Setting_Gamepad_Style Cateye"]
 string Setting_Gamepad_Font = "DroidSans.ttf";
 
@@ -191,6 +197,9 @@ bool Setting_Keyboard_ArrowSymbols = true;
 
 [Setting category="Keyboard" name="Display steer percentage" description="Overrides left/right arrows of setting above"]
 bool Setting_Keyboard_SteerPercentage = false;
+
+[Setting category="Keyboard" name="Display steer percentage symbol"]
+bool Setting_Keyboard_SteerPercentageSymbol = true;
 
 [Setting category="Keyboard" name="Font"]
 string Setting_Keyboard_Font = "DroidSans.ttf";

--- a/Source/Settings.as
+++ b/Source/Settings.as
@@ -128,18 +128,18 @@ bool Setting_Gamepad_CateyeUseSimpleSteer = false;
 [Setting category="Gamepad" name="Display steer percentage" if="Setting_Gamepad_Style Uniform"]
 bool Setting_Gamepad_SteerPercentage = false;
 
-[Setting
-	category="Gamepad"
-	name="Steer percentage size"
-	drag min=2 max=40
-	if="Setting_Gamepad_Style Uniform"]
-int Setting_Gamepad_SteerPercentageSize = 16;
-
 [Setting category="Gamepad" name="Font" if="Setting_Gamepad_Style Uniform"]
 string Setting_Gamepad_Font = "DroidSans.ttf";
 
-[Setting category="Gamepad" name="Text and symbol color" color if="Setting_Gamepad_Style Uniform"]
-vec4 Setting_Gamepad_TextColor = vec4(1, 1, 1, 1);
+[Setting
+	category="Gamepad"
+	name="Font size"
+	min=2 max=40
+	if="Setting_Gamepad_Style Uniform"]
+int Setting_Gamepad_FontSize = 16;
+
+[Setting category="Gamepad" name="Font color" color if="Setting_Gamepad_Style Uniform"]
+vec4 Setting_Gamepad_FontColor = vec4(1, 1, 1, 1);
 
 
 
@@ -192,17 +192,17 @@ bool Setting_Keyboard_ArrowSymbols = true;
 [Setting category="Keyboard" name="Display steer percentage" description="Overrides left/right arrows of setting above"]
 bool Setting_Keyboard_SteerPercentage = false;
 
-[Setting
-	category="Keyboard"
-	name="Steer percentage size"
-	drag min=2 max=40]
-int Setting_Keyboard_SteerPercentageSize = 16;
-
 [Setting category="Keyboard" name="Font"]
 string Setting_Keyboard_Font = "DroidSans.ttf";
 
-[Setting category="Keyboard" name="Text and symbol color" color]
-vec4 Setting_Keyboard_TextColor = vec4(1, 1, 1, 1);
+[Setting
+	category="Keyboard"
+	name="Font size"
+	min=2 max=40]
+int Setting_Keyboard_FontSize = 16;
+
+[Setting category="Keyboard" name="Font color" color]
+vec4 Setting_Keyboard_FontColor = vec4(1, 1, 1, 1);
 
 
 

--- a/Source/Settings.as
+++ b/Source/Settings.as
@@ -183,6 +183,9 @@ float Setting_Keyboard_Spacing = 10.0f;
 [Setting category="Keyboard" name="Inactive alpha" drag min=0 max=1]
 float Setting_Keyboard_InactiveAlpha = 1.0f;
 
+[Setting category="Keyboard" name="Display arrow symbols"]
+bool Setting_Keyboard_ArrowSymbols = true;
+
 
 
 [Setting category="Gearbox" name="Show text"]

--- a/Source/Settings.as
+++ b/Source/Settings.as
@@ -186,6 +186,9 @@ float Setting_Keyboard_InactiveAlpha = 1.0f;
 [Setting category="Keyboard" name="Display arrow symbols"]
 bool Setting_Keyboard_ArrowSymbols = true;
 
+[Setting category="Keyboard" name="Text and symbol color" color]
+vec4 Setting_Keyboard_TextColor = vec4(1, 1, 1, 1);
+
 
 
 [Setting category="Gearbox" name="Show text"]

--- a/Source/Settings.as
+++ b/Source/Settings.as
@@ -186,6 +186,15 @@ float Setting_Keyboard_InactiveAlpha = 1.0f;
 [Setting category="Keyboard" name="Display arrow symbols"]
 bool Setting_Keyboard_ArrowSymbols = true;
 
+[Setting category="Keyboard" name="Display steer percentage" description="Overrides left/right arrows of setting above"]
+bool Setting_Keyboard_SteerPercentage = false;
+
+[Setting
+	category="Keyboard"
+	name="Steer percentage size"
+	drag min=2 max=40]
+int Setting_Keyboard_SteerPercentageSize = 16;
+
 [Setting category="Keyboard" name="Text and symbol color" color]
 vec4 Setting_Keyboard_TextColor = vec4(1, 1, 1, 1);
 

--- a/Source/Settings.as
+++ b/Source/Settings.as
@@ -144,8 +144,8 @@ string Setting_Gamepad_Font = "DroidSans.ttf";
 	if="!Setting_Gamepad_Style Cateye"]
 int Setting_Gamepad_FontSize = 16;
 
-[Setting category="Gamepad" name="Font color" color if="!Setting_Gamepad_Style Cateye"]
-vec4 Setting_Gamepad_FontColor = vec4(1, 1, 1, 1);
+[Setting category="Gamepad" name="Text color" color if="!Setting_Gamepad_Style Cateye"]
+vec4 Setting_Gamepad_TextColor = vec4(1, 1, 1, 1);
 
 
 
@@ -210,8 +210,8 @@ string Setting_Keyboard_Font = "DroidSans.ttf";
 	min=2 max=40]
 int Setting_Keyboard_FontSize = 16;
 
-[Setting category="Keyboard" name="Font color" color]
-vec4 Setting_Keyboard_FontColor = vec4(1, 1, 1, 1);
+[Setting category="Keyboard" name="Text color" color]
+vec4 Setting_Keyboard_TextColor = vec4(1, 1, 1, 1);
 
 
 

--- a/Source/Settings.as
+++ b/Source/Settings.as
@@ -141,7 +141,7 @@ float Setting_Gamepad_SteerPercentageSpacing = 0.0f;
 string Setting_Gamepad_Font = "DroidSans.ttf";
 
 [Setting category="Gamepad" name="Font size" min=2 max=40]
-int Setting_Gamepad_FontSize = 16;
+int Setting_Gamepad_SteerPercentageSize = 16;  // also used for arrows
 
 [Setting category="Gamepad" name="Text color" color]
 vec4 Setting_Gamepad_TextColor = vec4(1, 1, 1, 1);

--- a/Source/Settings.as
+++ b/Source/Settings.as
@@ -206,10 +206,7 @@ bool Setting_Keyboard_SteerPercentageSymbol = true;
 [Setting category="Keyboard" name="Font"]
 string Setting_Keyboard_Font = "DroidSans.ttf";
 
-[Setting
-	category="Keyboard"
-	name="Font size"
-	min=2 max=40]
+[Setting category="Keyboard" name="Font size" min=2 max=40]
 int Setting_Keyboard_FontSize = 16;
 
 [Setting category="Keyboard" name="Text color" color]

--- a/Source/Settings.as
+++ b/Source/Settings.as
@@ -116,8 +116,11 @@ vec4 Setting_Gamepad_ClassicUpColor = vec4(0.2f, 1, 0.6f, 1);
 [Setting category="Gamepad" name="Classic down color" color if="Setting_Gamepad_Style Classic"]
 vec4 Setting_Gamepad_ClassicDownColor = vec4(1, 0.6f, 0.2f, 1);
 
-[Setting category="Gamepad" name="Classic off alpha" drag min=0 max=1 if="Setting_Gamepad_Style Classic"]
+[Setting category="Gamepad" name="Inactive alpha" drag min=0 max=1]
 float Setting_Gamepad_OffAlpha = 0.33f;
+
+[Setting category="Gamepad" name="Use inactive alpha for text"]
+bool Setting_Gamepad_OffAlphaText = true;
 
 [Setting category="Gamepad" name="Display up/down arrow symbols" if="Setting_Gamepad_Style Uniform"]
 bool Setting_Gamepad_UpDownSymbols = true;

--- a/Source/Settings.as
+++ b/Source/Settings.as
@@ -140,11 +140,7 @@ float Setting_Gamepad_SteerPercentageSpacing = 0.0f;
 [Setting category="Gamepad" name="Font"]
 string Setting_Gamepad_Font = "DroidSans.ttf";
 
-[Setting
-	category="Gamepad"
-	name="Font size"
-	min=2 max=40
-	if="!Setting_Gamepad_Style Cateye"]
+[Setting category="Gamepad" name="Font size" min=2 max=40]
 int Setting_Gamepad_FontSize = 16;
 
 [Setting category="Gamepad" name="Text color" color]

--- a/Source/Settings.as
+++ b/Source/Settings.as
@@ -198,7 +198,7 @@ bool Setting_Keyboard_ArrowSymbols = true;
 [Setting category="Keyboard" name="Display steer percentage" description="Overrides left/right arrows of setting above"]
 bool Setting_Keyboard_SteerPercentage = false;
 
-[Setting category="Keyboard" name="Display steer percentage symbol"]
+[Setting category="Keyboard" name="Display steer percentage symbol" if="Setting_Keyboard_SteerPercentage"]
 bool Setting_Keyboard_SteerPercentageSymbol = true;
 
 [Setting category="Keyboard" name="Font"]

--- a/Source/Settings.as
+++ b/Source/Settings.as
@@ -147,7 +147,7 @@ string Setting_Gamepad_Font = "DroidSans.ttf";
 	if="!Setting_Gamepad_Style Cateye"]
 int Setting_Gamepad_FontSize = 16;
 
-[Setting category="Gamepad" name="Text color" color if="!Setting_Gamepad_Style Cateye"]
+[Setting category="Gamepad" name="Text color" color]
 vec4 Setting_Gamepad_TextColor = vec4(1, 1, 1, 1);
 
 

--- a/Source/Settings.as
+++ b/Source/Settings.as
@@ -128,16 +128,16 @@ bool Setting_Gamepad_UpDownSymbols = true;
 [Setting category="Gamepad" name="Cateye use simple steer" if="Setting_Gamepad_Style Cateye"]
 bool Setting_Gamepad_CateyeUseSimpleSteer = false;
 
-[Setting category="Gamepad" name="Display steer percentage" if="!Setting_Gamepad_Style Cateye"]
+[Setting category="Gamepad" name="Display steer percentage"]
 bool Setting_Gamepad_SteerPercentage = false;
 
-[Setting category="Gamepad" name="Display steer percentage symbol" if="!Setting_Gamepad_Style Cateye"]
+[Setting category="Gamepad" name="Display steer percentage symbol" if="Setting_Gamepad_SteerPercentage"]
 bool Setting_Gamepad_SteerPercentageSymbol = true;
 
-[Setting category="Gamepad" name="Steer percentage spacing" min=-100 max=100 if="!Setting_Gamepad_Style Cateye"]
+[Setting category="Gamepad" name="Steer percentage spacing" min=-100 max=100]
 float Setting_Gamepad_SteerPercentageSpacing = 0.0f;
 
-[Setting category="Gamepad" name="Font" if="!Setting_Gamepad_Style Cateye"]
+[Setting category="Gamepad" name="Font"]
 string Setting_Gamepad_Font = "DroidSans.ttf";
 
 [Setting

--- a/Source/Settings.as
+++ b/Source/Settings.as
@@ -195,6 +195,9 @@ float Setting_Keyboard_Spacing = 10.0f;
 [Setting category="Keyboard" name="Inactive alpha" drag min=0 max=1]
 float Setting_Keyboard_InactiveAlpha = 1.0f;
 
+[Setting category="Keyboard" name="Use inactive alpha for text"]
+bool Setting_Gamepad_InactiveAlphaText = true;
+
 [Setting category="Keyboard" name="Display arrow symbols"]
 bool Setting_Keyboard_ArrowSymbols = true;
 

--- a/Source/Things/Acceleration.as
+++ b/Source/Things/Acceleration.as
@@ -47,7 +47,7 @@ class DashboardAcceleration : DashboardThing
 		}
 
 		auto font = nvg::LoadFont(Setting_Acceleration_Font);
-		if (font > 0) {
+		if (font >= 0) {
 			m_fontPath = Setting_Acceleration_Font;
 			m_font = font;
 		}

--- a/Source/Things/Clock.as
+++ b/Source/Things/Clock.as
@@ -42,7 +42,7 @@ class DashboardClock : DashboardThing
 		}
 
 		auto font = nvg::LoadFont(Setting_Clock_Font);
-		if (font > 0) {
+		if (font >= 0) {
 			m_fontPath = Setting_Clock_Font;
 			m_font = font;
 		}

--- a/Source/Things/Gearbox.as
+++ b/Source/Things/Gearbox.as
@@ -45,7 +45,7 @@ class DashboardGearbox : DashboardThing
 		}
 
 		auto font = nvg::LoadFont(Setting_Gearbox_Font);
-		if (font > 0) {
+		if (font >= 0) {
 			m_fontPath = Setting_Gearbox_Font;
 			m_font = font;
 		}

--- a/Source/Things/PadHost.as
+++ b/Source/Things/PadHost.as
@@ -118,7 +118,8 @@ class DashboardPadHost : DashboardThing
 		}
 	}
 
-	void OnSettingsChanged() override {
+	void OnSettingsChanged() override
+	{
 		if (m_pad !is null) {
 			m_pad.OnSettingsChanged();
 		}

--- a/Source/Things/PadHost.as
+++ b/Source/Things/PadHost.as
@@ -1,5 +1,6 @@
 interface IDashboardPad
 {
+	void OnSettingsChanged();
 	void Render(const vec2 &in size, CSceneVehicleVisState@ vis);
 }
 
@@ -114,6 +115,12 @@ class DashboardPadHost : DashboardThing
 		switch (type) {
 			case PadType::Keyboard: @m_pad = DashboardPadKeyboard(); break;
 			case PadType::Gamepad: @m_pad = DashboardPadGamepad(); break;
+		}
+	}
+
+	void OnSettingsChanged() override {
+		if (m_pad !is null) {
+			m_pad.OnSettingsChanged();
 		}
 	}
 }

--- a/Source/Things/Speed.as
+++ b/Source/Things/Speed.as
@@ -42,7 +42,7 @@ class DashboardSpeed : DashboardThing
 		}
 
 		auto font = nvg::LoadFont(Setting_Speed_Font);
-		if (font > 0) {
+		if (font >= 0) {
 			m_fontPath = Setting_Speed_Font;
 			m_font = font;
 		}

--- a/Source/Things/Wheels.as
+++ b/Source/Things/Wheels.as
@@ -64,7 +64,7 @@ class DashboardWheels : DashboardThing
 		}
 
 		auto font = nvg::LoadFont(Setting_Wheels_DetailsFont);
-		if (font > 0) {
+		if (font >= 0) {
 			m_fontPath = Setting_Wheels_DetailsFont;
 			m_font = font;
 		}


### PR DESCRIPTION
Sorry it's probably still a bit of a large PR, but these are just the changes I made concerning text on the input display. Most changes are for consistency across modes (e.g. steer percentage), but some are for convenience (e.g. toggling the `%` symbol).

New settings:
- toggle inactive alpha on text (gamepad/keyboard)
- toggle arrows (keyboard)
- steer percentage (gamepad classic/gamepad cateye/keyboard)
- text color (keyboard)
- fonts (gamepad/keyboard)
- toggle percent symbol (gamepad/keyboard)
- steer percentage horizontal spacing (gamepad)

Fixed:
- loading default font